### PR TITLE
Add springio/antora-xref-extension

### DIFF
--- a/fleet-local-playbook.yml
+++ b/fleet-local-playbook.yml
@@ -24,6 +24,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@springio/antora-xref-extension'
 
 output:
   dir: build/site

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "dependencies": {
                 "@antora/lunr-extension": "^1.0.0-alpha.8",
+                "@springio/antora-xref-extension": "^1.0.0-alpha.4",
                 "asciidoctor-kroki": "^0.18.1"
             },
             "devDependencies": {
@@ -355,6 +356,14 @@
             "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
             "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
             "dev": true
+        },
+        "node_modules/@springio/antora-xref-extension": {
+            "version": "1.0.0-alpha.4",
+            "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+            "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ==",
+            "engines": {
+                "node": ">=20.0.0"
+            }
         },
         "node_modules/@vscode/gulp-vinyl-zip": {
             "version": "2.5.0",
@@ -3053,6 +3062,11 @@
             "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
             "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
             "dev": true
+        },
+        "@springio/antora-xref-extension": {
+            "version": "1.0.0-alpha.4",
+            "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+            "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ=="
         },
         "@vscode/gulp-vinyl-zip": {
             "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     },
     "dependencies": {
         "@antora/lunr-extension": "^1.0.0-alpha.8",
+        "@springio/antora-xref-extension": "^1.0.0-alpha.4",
         "asciidoctor-kroki": "^0.18.1"
     }
 }

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -25,3 +25,4 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@springio/antora-xref-extension'


### PR DESCRIPTION
Adds the [spring-io/antora-xref-extension](https://github.com/spring-io/antora-xref-extension) extension as Antora's built-in validation doesn't support xrefs with fragments (i.e. linking to the header of another file). 

Note, CI for this PR itself runs with the extension enabled and broken links of this type are considered `ERROR` level by the extension. If there are any such broken links, CI won't pass until the links are fixed.