### PR TITLE
Fix playbook name in workflow to match actual filename

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -26,7 +26,7 @@ jobs:
             --log-format=pretty \
             --log-level=info \
             --log-failure-level=warn \
-            playbook-local.yml 2>&1 | tee local-build.log 2>&1
+            fleet-local-playbook.yml 2>&1 | tee local-build.log 2>&1
             BUILD_STATUS=${PIPESTATUS[0]}
             if grep "INFO (asciidoctor)" local-build.log; then
               BUILD_STATUS=1


### PR DESCRIPTION
When submitting #31 I forgot to update playbook file name due to the naming convention differences between our repos. Note the local and remote playbooks within this repo also have different naming conventions (`fleet-local-playbook.yml` vs `playbook-remote.yml`).