### PR TITLE
Sync v0.10 Changelogs - Community to Product

### DIFF
--- a/versions/v0.10/modules/en/nav.adoc
+++ b/versions/v0.10/modules/en/nav.adoc
@@ -48,3 +48,8 @@
 * xref:troubleshooting.adoc[Troubleshooting]
 * Changelog
 ** xref:v0.10.0.adoc[v0.10.0]
+** xref:v0.10.1.adoc[v0.10.1]
+** xref:v0.10.2.adoc[v0.10.2]
+** xref:v0.10.3.adoc[v0.10.3]
+** xref:v0.10.4.adoc[v0.10.4]
+** xref:v0.10.6.adoc[v0.10.6]

--- a/versions/v0.10/modules/en/pages/v0.10.0.adoc
+++ b/versions/v0.10/modules/en/pages/v0.10.0.adoc
@@ -224,7 +224,7 @@ The {product_name} v0.10 release brings significant changes, including a redesig
 * Re-enable fossa by https://github.com/olblak[@olblak] in https://github.com/rancher/fleet/pull/2446[#2446]
 ====
 
-*Full Changelog*: https://github.com/rancher/fleet/compare/v0.9.5...v0.10.0[+++<tt>+++v0.9.5\...v0.10.0+++</tt>+++]
+*Full Changelog*: link:++https://github.com/rancher/fleet/compare/v0.9.5...v0.10.0++[v0.9.5...v0.10.0]
 
 == Download
 

--- a/versions/v0.10/modules/en/pages/v0.10.1.adoc
+++ b/versions/v0.10/modules/en/pages/v0.10.1.adoc
@@ -1,0 +1,44 @@
+= v0.10.1
+:date: 2024-08-15 04:25:51 +0000 UTC
+
+* (github-actions[bot]) released this 2024-08-15 04:25:51 +0000 UTC*
+
+== Description
+
+=== Additions
+
+* Add hostNetwork setting for agent deployment policy  in https://github.com/rancher/fleet/issues/2659[#2659]
+* Adding namespaceLabels and namespaceAnnotations as TargetCustomization in https://github.com/rancher/fleet/issues/2583[#2583]
+* Use node selector for git jobs in https://github.com/rancher/fleet/pull/2733[#2733]
+
+=== Bugfixes
+
+* Adds support for `folder/*` patterns in .fleetignore in https://github.com/rancher/fleet/pull/2617[#2617]
+* Fix extraEnv in gitjob controller helm template in https://github.com/rancher/fleet/pull/2650[#2650]
+* KubeVersion fix for fleet deploy --dry-run in https://github.com/rancher/fleet/pull/2730[#2730]
+
+=== What's Changed
+
+* Use RequeueAfter for Gitpolling job https://github.com/rancher/fleet/pull/2643[#2643]
+* Replace logrus with logger when querying targets in https://github.com/rancher/fleet/pull/2653[#2653]
+* Clean up content resources through finalizers in https://github.com/rancher/fleet/pull/2732[#2732]
+* Changes post render error when using targetNamespace or namespace in https://github.com/rancher/fleet/pull/2731[#2731]
+
+*Full Changelog*: link:++https://github.com/rancher/fleet/compare/v0.10.0...v0.10.1++[v0.10.0...v0.10.1]
+
+== Download
+
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet-0.10.1.tgz[fleet-0.10.1.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet-crd-0.10.1.tgz[fleet-crd-0.10.1.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet-agent-0.10.1.tgz[fleet-agent-0.10.1.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet_0.10.1_checksums.txt[fleet_0.10.1_checksums.txt]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleetagent-linux-amd64[fleetagent-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet-windows-amd64.exe[fleet-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet-linux-amd64[fleet-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleetagent-linux-arm64[fleetagent-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleet-linux-arm64[fleet-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleetcontroller-linux-arm64[fleetcontroller-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleetcontroller-linux-amd64[fleetcontroller-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.1/fleetagent-windows-amd64.exe[fleetagent-windows-amd64.exe]
+
+_Information retrieved from https://github.com/rancher/fleet/releases/tag/v0.10.1[here]_

--- a/versions/v0.10/modules/en/pages/v0.10.2.adoc
+++ b/versions/v0.10/modules/en/pages/v0.10.2.adoc
@@ -1,0 +1,35 @@
+= v0.10.2
+:date: 2024-09-13 12:27:15 +0000 UTC
+
+* (github-actions[bot]) released this 2024-09-13 12:27:15 +0000 UTC*
+
+== Description
+
+=== What's Changed
+
+* Make Helm release garbage collection interval configurable by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/2780[#2780]
+* Fixes status not being populated to cluster and clustergroups by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/2797[#2797]
+* Return error code 401 for auth errors in webhooks by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/2799[#2799]
+* Bump Go to 1.22.7 by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/2815[#2815]
+* Fixes finalizer deletion in bundle deployments by https://github.com/0xavi0[@0xavi0] in https://github.com/rancher/fleet/pull/2821[#2821]
+* Create cabundle secret by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2831[#2831]
+* Gitjob container has writable /tmp dir by https://github.com/manno[@manno] in https://github.com/rancher/fleet/pull/2830[#2830]
+
+*Full Changelog*: link:++https://github.com/rancher/fleet/compare/v0.10.1...v0.10.2++[v0.10.1...v0.10.2]
+
+== Download
+
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet-0.10.2.tgz[fleet-0.10.2.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet-agent-0.10.2.tgz[fleet-agent-0.10.2.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet-crd-0.10.2.tgz[fleet-crd-0.10.2.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet_0.10.2_checksums.txt[fleet_0.10.2_checksums.txt]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleetcontroller-linux-arm64[fleetcontroller-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet-linux-arm64[fleet-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleetagent-linux-amd64[fleetagent-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet-windows-amd64.exe[fleet-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleetcontroller-linux-amd64[fleetcontroller-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleet-linux-amd64[fleet-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleetagent-linux-arm64[fleetagent-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.2/fleetagent-windows-amd64.exe[fleetagent-windows-amd64.exe]
+
+_Information retrieved from https://github.com/rancher/fleet/releases/tag/v0.10.2[here]_

--- a/versions/v0.10/modules/en/pages/v0.10.3.adoc
+++ b/versions/v0.10/modules/en/pages/v0.10.3.adoc
@@ -1,0 +1,36 @@
+= v0.10.3
+:date: 2024-09-30 10:56:25 +0000 UTC
+
+* (github-actions[bot]) released this 2024-09-30 10:56:25 +0000 UTC*
+
+== Description
+
+=== Notes
+
+The cronjob to clean up outdated git cloning jobs, is using the wrong service account. `serviceAccountName` in the job template needs to be switched to the "gitjob" service account. Doing this edit in the Rancher UI didn't work while testing.
+Upgrading to the chart via the Rancher UI will not set new  Helm values, so `migrations.gitrepoJobsCleanup` will not be enabled. Customizing the Fleet installation options via the `rancher-config` configmap will work.
+
+=== What's Changed
+
+* Increase worker count for reconcilers by https://github.com/manno[@manno] https://github.com/rancher/fleet/commit/4b147db2ef644b012325dadd3c456cc781678374[(4b147db)]
+* Increase visibility of gitjob controller logs and events by https://github.com/weyfonk[@weyfonk] https://github.com/rancher/fleet/pull/2911[(#2911)]
+* Cleanup completed gitrepo jobs by https://github.com/manno[@manno] https://github.com/rancher/fleet/pull/2910[(#2910)]
+
+*Full Changelog*: link:++https://github.com/rancher/fleet/compare/v0.10.2...v0.10.3++[v0.10.2...v0.10.3]
+
+== Download
+
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet-agent-0.10.3.tgz[fleet-agent-0.10.3.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet-0.10.3.tgz[fleet-0.10.3.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet-crd-0.10.3.tgz[fleet-crd-0.10.3.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet_0.10.3_checksums.txt[fleet_0.10.3_checksums.txt]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet-windows-amd64.exe[fleet-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleetagent-windows-amd64.exe[fleetagent-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet-linux-arm64[fleet-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleetagent-linux-amd64[fleetagent-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleetcontroller-linux-arm64[fleetcontroller-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleetagent-linux-arm64[fleetagent-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleetcontroller-linux-amd64[fleetcontroller-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.3/fleet-linux-amd64[fleet-linux-amd64]
+
+_Information retrieved from https://github.com/rancher/fleet/releases/tag/v0.10.3[here]_

--- a/versions/v0.10/modules/en/pages/v0.10.4.adoc
+++ b/versions/v0.10/modules/en/pages/v0.10.4.adoc
@@ -1,0 +1,44 @@
+= v0.10.4
+:date: 2024-10-17 15:02:32 +0000 UTC
+
+* (github-actions[bot]) released this 2024-10-17 15:02:32 +0000 UTC*
+
+== Description
+
+=== What's Changed
+
+* Skip checks on logs in sharding end-to-end tests by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2838[#2838]
+* Propagate drift correction error to bundle deployment status by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2835[#2835]
+* Propagate drift correction force mode to Helm rollback by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2836[#2836]
+* Add integration test checks for CA bundle secret by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2863[#2863]
+* Tolerate unitialized node taint by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/2874[#2874]
+* Fix helm.sh/resource-policy being added to everything and not just CRDs by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/2875[#2875]
+* Backport of Increase worker count for reconcilers by https://github.com/manno[@manno] in https://github.com/rancher/fleet/pull/2900[#2900]
+* Increase visibility of gitjob controller logs and events by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2911[#2911]
+* Cleanup completed gitrepo jobs by https://github.com/manno[@manno] in https://github.com/rancher/fleet/pull/2910[#2910]
+* Convert drift e2e tests into integration tests by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2913[#2913]
+* Skip CA bundle secret creation with empty payload by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2923[#2923]
+* Changes job handling in gitops controller by https://github.com/0xavi0[@0xavi0] in https://github.com/rancher/fleet/pull/2932[#2932]
+* Converts the delete gitjobs to one-time job by https://github.com/0xavi0[@0xavi0] in https://github.com/rancher/fleet/pull/2936[#2936]
+* Fix job deletion when generation is not updated on time by https://github.com/0xavi0[@0xavi0] in https://github.com/rancher/fleet/pull/2945[#2945]
+* Limit `Deployed bundle` logs by https://github.com/weyfonk[@weyfonk] in https://github.com/rancher/fleet/pull/2946[#2946]
+* Cleanup jobs back to cronjob by https://github.com/0xavi0[@0xavi0] in https://github.com/rancher/fleet/pull/2952[#2952]
+
+*Full Changelog*: link:++https://github.com/rancher/fleet/compare/v0.10.3...v0.10.4++[v0.10.3...v0.10.4]
+
+== Download
+
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet-0.10.4.tgz[fleet-0.10.4.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet-agent-0.10.4.tgz[fleet-agent-0.10.4.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet-crd-0.10.4.tgz[fleet-crd-0.10.4.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet_0.10.4_checksums.txt[fleet_0.10.4_checksums.txt]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleetagent-linux-amd64[fleetagent-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleetagent-windows-amd64.exe[fleetagent-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleetcontroller-linux-amd64[fleetcontroller-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet-windows-amd64.exe[fleet-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleetcontroller-linux-arm64[fleetcontroller-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet-linux-amd64[fleet-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleet-linux-arm64[fleet-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.4/fleetagent-linux-arm64[fleetagent-linux-arm64]
+
+_Information retrieved from https://github.com/rancher/fleet/releases/tag/v0.10.4[here]_

--- a/versions/v0.10/modules/en/pages/v0.10.6.adoc
+++ b/versions/v0.10/modules/en/pages/v0.10.6.adoc
@@ -1,0 +1,34 @@
+= v0.10.6
+:date: 2024-11-15 15:19:27 +0000 UTC
+
+* (github-actions[bot]) released this 2024-11-15 15:19:27 +0000 UTC*
+
+== Description
+
+== What's Changed
+
+* [v0.10] Fix apply defaults from gitrepo restriction by https://github.com/manno[@manno] in https://github.com/rancher/fleet/pull/3084[#3084]
+* Fix status conflict between agent and fleetcontroller by https://github.com/aruiz14[@aruiz14] in https://github.com/rancher/fleet/pull/3005[#3005]
+* Backport of Adds predicate when webhook commit changes by https://github.com/0xavi0[@0xavi0] in https://github.com/rancher/fleet/pull/3006[#3006]
+* Update Go to 1.23 by https://github.com/thardeck[@thardeck] in https://github.com/rancher/fleet/pull/3013[#3013]
+* Use Patch instead of Update for modifying the status field by https://github.com/aruiz14[@aruiz14] in https://github.com/rancher/fleet/pull/3022[#3022]
+* Backport GitRepo status resources improvements by https://github.com/aruiz14[@aruiz14] in https://github.com/rancher/fleet/pull/3033[#3033]
+
+*Full Changelog*: link:++https://github.com/rancher/fleet/compare/v0.10.4...v0.10.6++[v0.10.4...v0.10.6]
+
+== Download
+
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet-0.10.6.tgz[fleet-0.10.6.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet-agent-0.10.6.tgz[fleet-agent-0.10.6.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet-crd-0.10.6.tgz[fleet-crd-0.10.6.tgz]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet_0.10.6_checksums.txt[fleet_0.10.6_checksums.txt]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet-windows-amd64.exe[fleet-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet-linux-amd64[fleet-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleet-linux-arm64[fleet-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleetagent-windows-amd64.exe[fleetagent-windows-amd64.exe]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleetagent-linux-amd64[fleetagent-linux-amd64]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleetcontroller-linux-arm64[fleetcontroller-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleetagent-linux-arm64[fleetagent-linux-arm64]
+* https://github.com/rancher/fleet/releases/download/v0.10.6/fleetcontroller-linux-amd64[fleetcontroller-linux-amd64]
+
+_Information retrieved from https://github.com/rancher/fleet/releases/tag/v0.10.6[here]_


### PR DESCRIPTION
Syncing the [v0.10 Community Changelog section](https://github.com/rancher/fleet-docs/tree/main/versioned_docs/version-0.10/changelogs/changelogs) to Product. For reference, this PR added the v0.10.1-v0.10.6 changelogs on the Community side: https://github.com/rancher/fleet-docs/pull/202