### PR TITLE
Updating Missing Nav Entries

### DIFF
--- a/versions/v0.11/modules/en/nav.adoc
+++ b/versions/v0.11/modules/en/nav.adoc
@@ -31,6 +31,7 @@
 *** xref:reference/cli/fleet-cli/fleet_apply.adoc[fleet apply]
 *** xref:reference/cli/fleet-cli/fleet_cleanup.adoc[fleet cleanup]
 *** xref:reference/cli/fleet-cli/fleet_deploy.adoc[fleet deploy]
+*** xref:reference/cli/fleet-cli/fleet_gitcloner.adoc[fleet gitcloner]
 *** xref:reference/cli/fleet-cli/fleet_target.adoc[fleet target]
 *** xref:reference/cli/fleet-cli/fleet_test.adoc[fleet test]
 *** xref:reference/cli/fleet-controller/fleet-controller.adoc[fleet-controller]

--- a/versions/v0.9/modules/en/nav.adoc
+++ b/versions/v0.9/modules/en/nav.adoc
@@ -27,6 +27,7 @@
 *** xref:reference/cli/fleet-agent/fleet-agent.adoc[fleet-agent]
 *** xref:reference/cli/fleet-cli/fleet.adoc[fleet]
 *** xref:reference/cli/fleet-cli/fleet_apply.adoc[fleet apply]
+*** xref:reference/cli/fleet-cli/fleet_cleanup.adoc[fleet cleanup]
 *** xref:reference/cli/fleet-cli/fleet_test.adoc[fleet test]
 *** xref:reference/cli/fleet-controller/fleet-manager.adoc[fleet-manager]
 ** xref:reference/ref-status-fields.adoc[Cluster and Bundle State]


### PR DESCRIPTION
Updating missing nav entries for 'fleet cleanup' and 'fleet gitcloner' and also will update on Community with follow-up PR. Also removing an empty leftover file.
Fixes #50 