### PR TITLE
Add missing nav script and include check in CI

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -32,6 +32,8 @@ jobs:
               BUILD_STATUS=1
             fi
             echo "BUILD_STATUS=$BUILD_STATUS" >> $GITHUB_ENV
+      - name: Check files for missing nav entries
+        run: bin/files-missing-nav
       - name: Check for build errors
         run: |
           echo ${{ env.BUILD_STATUS }}

--- a/bin/files-missing-nav
+++ b/bin/files-missing-nav
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+DOCS_DIR="docs"
+
+# Naming convention inconsistent. Check for other variation.
+if [ -d versions ]; then
+  DOCS_DIR="versions"
+fi
+
+if test -f tmp/files-missing-nav.log; then
+    truncate -s 0 tmp/files-missing-nav.log
+elif ! test -d tmp; then
+    mkdir tmp
+fi
+
+MODULE_LANG_DIRS=$(find $DOCS_DIR -type d -iname "pages")
+
+for dir in $MODULE_LANG_DIRS; do
+    MODULE_LANG_FILES=$(find $dir -type f -iname "*.adoc" ! -iname "_*.adoc")
+    for file in $MODULE_LANG_FILES; do
+        MODULE_LANG_RELATIVE_PATH=${file#$dir}
+        MODULE_LANG_RELATIVE_PATH=${MODULE_LANG_RELATIVE_PATH#/}
+        NAV_FILE="${dir%pages}nav.adoc"
+        
+        if ! grep -q $MODULE_LANG_RELATIVE_PATH $NAV_FILE; then
+            echo $file >> tmp/files-missing-nav.log
+        fi
+    done
+done
+
+if test -f tmp/files-missing-nav.log; then
+    cat tmp/files-missing-nav.log
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
## Description

Add a script that checks for files missing a corresponding nav entry. The check has been added to the [test-deploy](https://github.com/rancher/fleet-product-docs/blob/main/.github/workflows/test-deploy.yml) workflow and also available to run during local development. 