### PR TITLE
Fix syntax errors

### DIFF
--- a/fleet-local-playbook.yml
+++ b/fleet-local-playbook.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
     - url: ./
-      start_paths: [versions/next, versions/v0.12, versions/v0.11, versions/v0.10, versions/v0.9]
+      start_paths: [versions/v0.12, versions/v0.11, versions/v0.10, versions/v0.9]
       branches: HEAD
 
 # Description: SUSE UI bundle

--- a/fleet-local-playbook.yml
+++ b/fleet-local-playbook.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
     - url: ./
-      start_paths: [versions/v0.12, versions/v0.11, versions/v0.10, versions/v0.9]
+      start_paths: [versions/next, versions/v0.12, versions/v0.11, versions/v0.10, versions/v0.9]
       branches: HEAD
 
 # Description: SUSE UI bundle

--- a/versions/next/antora.yml
+++ b/versions/next/antora.yml
@@ -3,5 +3,8 @@ title: Continuous Delivery
 version: next
 display_version: 'Next'
 start_page: en:index.adoc
+asciidoc:
+  attributes:
+    product_name: SUSE® Rancher Prime Continuous Delivery
 nav:
   - modules/en/nav.adoc

--- a/versions/next/modules/en/pages/how-tos-for-operators/installation.adoc
+++ b/versions/next/modules/en/pages/how-tos-for-operators/installation.adoc
@@ -2,11 +2,9 @@
 
 = Installation Details
 
-The installation is broken up into two different use cases: single and multi-cluster.
-The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
+The installation is broken up into two different use cases: single and multi-cluster. The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
 
-If you are just learning {product_name} the single cluster install is the recommended starting
-point. After which you can move from single cluster to multi-cluster setup down the line.
+If you are just learning {product_name} the single cluster install is the recommended starting point. After which you can move from single cluster to multi-cluster setup down the line.
 
 image::single-cluster.png[Static, 600]
 
@@ -51,14 +49,16 @@ Second install the {product_name} CustomResourcesDefintions.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \\ fleet/fleet-crd
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \
+    fleet/fleet-crd
 ----
 
 Third install the {product_name} controllers.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet \\ fleet/fleet
+helm -n cattle-fleet-system install --create-namespace --wait fleet \
+    fleet/fleet
 ----
 --
 
@@ -66,13 +66,17 @@ Verify::
 +
 --
 {product_name} should be ready to use now for single cluster. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 
@@ -84,17 +88,15 @@ You can now xref:how-tos-for-users/gitrepo-add.adoc[register some git repos] in 
 
 === Deployment
 
-From 0.10 onwards, {product_name} supports static sharding.
-Each shard is defined by its shard ID.
-Optionally, a shard can have a [node
-selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), instructing {product_name} to
-create all controller pods and jobs for that shard on nodes matching that selector.
+From 0.10 onwards, {product_name} supports static sharding. Each shard is defined by its shard ID. Optionally, a shard can have a https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[node selector], instructing {product_name} to create all controller pods and jobs for that shard on nodes matching that selector.
 
 The {product_name} controller chart can be installed with the following arguments:
+
 * `--set shards[$index].id=$shard_id`
 * `--set shards[$index].nodeSelector.$key=$value`
 
 This will result in:
+
 * as many {product_name} controller and gitjob deployments as specified unique shard IDs,
 * plus the usual unsharded {product_name} controller pod. That latter pod will be the only one containing agent management and cleanup containers.
 
@@ -129,11 +131,10 @@ gitjob-shard-foo-8697bb7f67-wzsfj   foo        k3d-upstream-server-0
 
 === How it works
 
-With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the
-unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
+With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
 
-To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a
-value.
+To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a value.
+
 Here is an example:
 
 [,bash]
@@ -152,11 +153,9 @@ spec:
 EOF
 ----
 
-A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be
-processed by that controller.
+A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be processed by that controller.
 
-On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any
-{product_name} controller, hence no resources other than the GitRepo itself will be created.
+On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any {product_name} controller, hence no resources other than the GitRepo itself will be created.
 
 Removing or adding supported shard IDs currently requires redeploying {product_name} with a new set of shard IDs.
 
@@ -171,8 +170,7 @@ The multi-cluster install described below is *only* covered in standalone Fleet,
 
 [IMPORTANT]
 ====
-The setup is the same as for a single cluster.
-After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
+The setup is the same as for a single cluster. After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
 
 However, to allow for xref:how-tos-for-operators/cluster-registration.adoc#_manager_initiated[manager-initiated registration] of downstream clusters, a few extra settings are required. Without the API server URL and the CA, only xref:how-tos-for-operators/cluster-registration.adoc#_agent_initiated[agent-initiated registration] of downstream clusters is possible.
 ====
@@ -180,30 +178,21 @@ However, to allow for xref:how-tos-for-operators/cluster-registration.adoc#_mana
 
 === API Server URL and CA certificate
 
-In order for your {product_name} management installation to properly work it is important
-the correct API server URL and CA certificates are configured properly.  The {product_name} agents
-will communicate to the Kubernetes API server URL. This means the Kubernetes
-API server must be accessible to the downstream clusters.  You will also need
-to obtain the CA certificate of the API server. The easiest way to obtain this information
-is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`,
-`certificate-authority-data`, or `certificate-authority` fields will have these values.
+In order for your {product_name} management installation to properly work it is important the correct API server URL and CA certificates are configured properly.  The {product_name} agents will communicate to the Kubernetes API server URL. This means the Kubernetes API server must be accessible to the downstream clusters.  You will also need to obtain the CA certificate of the API server. The easiest way to obtain this information is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`, `certificate-authority-data`, or `certificate-authority` fields will have these values.
 
 [,yaml]
+.$HOME/.kube/config
 ----
-title="$HOME/.kube/config"
 apiVersion: v1
 clusters:
-
-* cluster:
-  certificate-authority-data: LS0tLS1CRUdJTi...
-  server: https://<EXAMPLE_URL>:6443
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    server: https://example.com:6443
 ----
 
 ==== Extract CA certificate
 
-Please note that the `certificate-authority-data` field is base64 encoded and will need to be
-decoded before you save it into a file. This can be done by saving the base64 encoded contents to
-a file and then running
+Please note that the `certificate-authority-data` field is base64 encoded and will need to be decoded before you save it into a file. This can be done by saving the base64 encoded contents to a file and then running:
 
 [,shell]
 ----
@@ -218,9 +207,10 @@ Extract First::
 +
 --
 If you have `jq` and `base64` available then this one-liners will pull all CA certificates from your `KUBECONFIG` and place then in a file named `ca.pem`.
+
 [,shell]
 ----
-kubectl config view -o json --raw | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 
@@ -228,10 +218,11 @@ Multiple Entries::
 +
 --
 Or, if you have a multi-cluster setup, you can use this command: 
+
 [,shell]
 ----
 # replace CLUSTERNAME with the name of the cluster according to your KUBECONFIG
-kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 ====
@@ -257,22 +248,16 @@ First validate the server URL is correct.
 curl -fLk "$API_SERVER_URL/version"
 ----
 
-The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error.
-If you do not get either of these results than please ensure you have the correct URL. The API server port is typically
-6443 for Kubernetes.
+The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error. If you do not get either of these results than please ensure you have the correct URL. The API server port is typically 6443 for Kubernetes.
 
-Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a
-well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
+Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
 
 [,shell]
 ----
 curl -fL --cacert "$API_SERVER_CA" "$API_SERVER_URL/version"
 ----
 
-If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is
-only because the curl command is not setting proper credentials, but this validates that the TLS
-connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then
-the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
+If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is only because the curl command is not setting proper credentials, but this validates that the TLS connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
 
 [,pem]
 .ca.pem
@@ -291,9 +276,7 @@ KDs/pb3fnMTtpA==
 
 === Install for Multi-Cluster
 
-In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `https://example.com:6443`
-and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can
-omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
+In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `https://example.com:6443` and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
 
 Setup the environment with your specific values, e.g.:
 
@@ -303,28 +286,36 @@ API_SERVER_URL="https://example.com:6443"
 API_SERVER_CA="ca.pem"
 ----
 
-Once you have validated the API server URL and API server CA parameters, install the following two
-Helm charts.
+Once you have validated the API server URL and API server CA parameters, install the following two Helm charts.
 
 [tabs]
 ====
 Install::
 +
 --
-First add Fleet's Helm repository. 
+First add Fleet's Helm repository.
+
 [,bash]
 ----
 helm repo add fleet https://rancher.github.io/fleet-helm-charts/
 ----
+
 Second install the {product_name} CustomResourcesDefintions.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ fleet-crd`} {versions.next.fleetCRD}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    fleet-crd fleet/fleet-crd
 ----
+
 Third install the {product_name} controllers.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ --set apiServerURL="$API_SERVER_URL" \\ --set-file apiServerCA="$API_SERVER_CA" \\ fleet`} {versions.next.fleet}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    --set apiServerURL="$API_SERVER_URL" \
+    --set-file apiServerCA="$API_SERVER_CA" \
+    fleet fleet/fleet
 ----
 --
 
@@ -332,16 +323,19 @@ Verify::
 +
 --
 {product_name} should be ready to use. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 ====
 
-At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with
-the {product_name} manager.
+At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with the {product_name} manager.

--- a/versions/next/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
+++ b/versions/next/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
@@ -11,6 +11,7 @@ This leads the status of the bundle and associated GitRepo to be reported as "Mo
 image::ModifiedGitRepo.png[Static, 600]
 
 Associated Bundle
+
 image::ModifiedBundle.png[Static, 600]
 
 {product_name} bundles support the ability to specify a custom http://jsonpatch.com/[jsonPointer patch].

--- a/versions/v0.10/modules/en/pages/how-tos-for-operators/installation.adoc
+++ b/versions/v0.10/modules/en/pages/how-tos-for-operators/installation.adoc
@@ -2,11 +2,9 @@
 
 = Installation Details
 
-The installation is broken up into two different use cases: single and multi-cluster.
-The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
+The installation is broken up into two different use cases: single and multi-cluster. The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
 
-If you are just learning {product_name} the single cluster install is the recommended starting
-point. After which you can move from single cluster to multi-cluster setup down the line.
+If you are just learning {product_name} the single cluster install is the recommended starting point. After which you can move from single cluster to multi-cluster setup down the line.
 
 image::single-cluster.png[Static, 600]
 
@@ -51,14 +49,16 @@ Second install the {product_name} CustomResourcesDefintions.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \\ fleet/fleet-crd
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \
+    fleet/fleet-crd
 ----
 
 Third install the {product_name} controllers.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet \\ fleet/fleet
+helm -n cattle-fleet-system install --create-namespace --wait fleet \
+    fleet/fleet
 ----
 --
 
@@ -66,13 +66,17 @@ Verify::
 +
 --
 {product_name} should be ready to use now for single cluster. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 
@@ -84,17 +88,15 @@ You can now xref:how-tos-for-users/gitrepo-add.adoc[register some git repos] in 
 
 === Deployment
 
-From 0.10 onwards, {product_name} supports static sharding.
-Each shard is defined by its shard ID.
-Optionally, a shard can have a [node
-selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), instructing {product_name} to
-create all controller pods and jobs for that shard on nodes matching that selector.
+From 0.10 onwards, {product_name} supports static sharding. Each shard is defined by its shard ID. Optionally, a shard can have a https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[node selector], instructing {product_name} to create all controller pods and jobs for that shard on nodes matching that selector.
 
 The {product_name} controller chart can be installed with the following arguments:
+
 * `--set shards[$index].id=$shard_id`
 * `--set shards[$index].nodeSelector.$key=$value`
 
 This will result in:
+
 * as many {product_name} controller and gitjob deployments as specified unique shard IDs,
 * plus the usual unsharded {product_name} controller pod. That latter pod will be the only one containing agent management and cleanup containers.
 
@@ -129,11 +131,10 @@ gitjob-shard-foo-8697bb7f67-wzsfj   foo        k3d-upstream-server-0
 
 === How it works
 
-With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the
-unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
+With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
 
-To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a
-value.
+To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a value.
+
 Here is an example:
 
 [,bash]
@@ -152,11 +153,9 @@ spec:
 EOF
 ----
 
-A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be
-processed by that controller.
+A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be processed by that controller.
 
-On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any
-{product_name} controller, hence no resources other than the GitRepo itself will be created.
+On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any {product_name} controller, hence no resources other than the GitRepo itself will be created.
 
 Removing or adding supported shard IDs currently requires redeploying {product_name} with a new set of shard IDs.
 
@@ -171,8 +170,7 @@ The multi-cluster install described below is *only* covered in standalone Fleet,
 
 [IMPORTANT]
 ====
-The setup is the same as for a single cluster.
-After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
+The setup is the same as for a single cluster. After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
 
 However, to allow for xref:how-tos-for-operators/cluster-registration.adoc#_manager_initiated[manager-initiated registration] of downstream clusters, a few extra settings are required. Without the API server URL and the CA, only xref:how-tos-for-operators/cluster-registration.adoc#_agent_initiated[agent-initiated registration] of downstream clusters is possible.
 ====
@@ -180,30 +178,21 @@ However, to allow for xref:how-tos-for-operators/cluster-registration.adoc#_mana
 
 === API Server URL and CA certificate
 
-In order for your {product_name} management installation to properly work it is important
-the correct API server URL and CA certificates are configured properly.  The {product_name} agents
-will communicate to the Kubernetes API server URL. This means the Kubernetes
-API server must be accessible to the downstream clusters.  You will also need
-to obtain the CA certificate of the API server. The easiest way to obtain this information
-is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`,
-`certificate-authority-data`, or `certificate-authority` fields will have these values.
+In order for your {product_name} management installation to properly work it is important the correct API server URL and CA certificates are configured properly.  The {product_name} agents will communicate to the Kubernetes API server URL. This means the Kubernetes API server must be accessible to the downstream clusters.  You will also need to obtain the CA certificate of the API server. The easiest way to obtain this information is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`, `certificate-authority-data`, or `certificate-authority` fields will have these values.
 
 [,yaml]
+.$HOME/.kube/config
 ----
-title="$HOME/.kube/config"
 apiVersion: v1
 clusters:
-
-* cluster:
-  certificate-authority-data: LS0tLS1CRUdJTi...
-  server: https://<EXAMPLE_URL>:6443
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    server: https://example.com:6443
 ----
 
 ==== Extract CA certificate
 
-Please note that the `certificate-authority-data` field is base64 encoded and will need to be
-decoded before you save it into a file. This can be done by saving the base64 encoded contents to
-a file and then running
+Please note that the `certificate-authority-data` field is base64 encoded and will need to be decoded before you save it into a file. This can be done by saving the base64 encoded contents to a file and then running:
 
 [,shell]
 ----
@@ -218,9 +207,10 @@ Extract First::
 +
 --
 If you have `jq` and `base64` available then this one-liners will pull all CA certificates from your `KUBECONFIG` and place then in a file named `ca.pem`.
+
 [,shell]
 ----
-kubectl config view -o json --raw | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 
@@ -228,10 +218,11 @@ Multiple Entries::
 +
 --
 Or, if you have a multi-cluster setup, you can use this command: 
+
 [,shell]
 ----
 # replace CLUSTERNAME with the name of the cluster according to your KUBECONFIG
-kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 ====
@@ -257,22 +248,16 @@ First validate the server URL is correct.
 curl -fLk "$API_SERVER_URL/version"
 ----
 
-The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error.
-If you do not get either of these results than please ensure you have the correct URL. The API server port is typically
-6443 for Kubernetes.
+The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error. If you do not get either of these results than please ensure you have the correct URL. The API server port is typically 6443 for Kubernetes.
 
-Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a
-well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
+Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
 
 [,shell]
 ----
 curl -fL --cacert "$API_SERVER_CA" "$API_SERVER_URL/version"
 ----
 
-If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is
-only because the curl command is not setting proper credentials, but this validates that the TLS
-connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then
-the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
+If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is only because the curl command is not setting proper credentials, but this validates that the TLS connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
 
 [,pem]
 .ca.pem
@@ -289,11 +274,9 @@ KDs/pb3fnMTtpA==
 ----END CERTIFICATE----
 ----
 
-### Install for Multi-Cluster
+=== Install for Multi-Cluster
 
-In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `https://example.com:6443`
-and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can
-omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
+In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `+https://example.com:6443+` and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
 
 Setup the environment with your specific values, e.g.:
 
@@ -303,28 +286,36 @@ API_SERVER_URL="https://example.com:6443"
 API_SERVER_CA="ca.pem"
 ----
 
-Once you have validated the API server URL and API server CA parameters, install the following two
-Helm charts.
+Once you have validated the API server URL and API server CA parameters, install the following two Helm charts.
 
 [tabs]
 ====
 Install::
 +
 --
-First add Fleet's Helm repository. 
+First add Fleet's Helm repository.
+
 [,bash]
 ----
 helm repo add fleet https://rancher.github.io/fleet-helm-charts/
 ----
+
 Second install the {product_name} CustomResourcesDefintions.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ fleet-crd`} {versions.next.fleetCRD}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    fleet-crd fleet/fleet-crd
 ----
+
 Third install the {product_name} controllers.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ --set apiServerURL="$API_SERVER_URL" \\ --set-file apiServerCA="$API_SERVER_CA" \\ fleet`} {versions.next.fleet}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    --set apiServerURL="$API_SERVER_URL" \
+    --set-file apiServerCA="$API_SERVER_CA" \
+    fleet fleet/fleet
 ----
 --
 
@@ -332,16 +323,19 @@ Verify::
 +
 --
 {product_name} should be ready to use. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 ====
 
-At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with
-the {product_name} manager.
+At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with the {product_name} manager.

--- a/versions/v0.10/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
+++ b/versions/v0.10/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
@@ -11,6 +11,7 @@ This leads the status of the bundle and associated GitRepo to be reported as "Mo
 image::ModifiedGitRepo.png[Static, 600]
 
 Associated Bundle
+
 image::ModifiedBundle.png[Static, 600]
 
 {product_name} bundles support the ability to specify a custom http://jsonpatch.com/[jsonPointer patch].

--- a/versions/v0.11/modules/en/pages/how-tos-for-operators/installation.adoc
+++ b/versions/v0.11/modules/en/pages/how-tos-for-operators/installation.adoc
@@ -2,11 +2,9 @@
 
 = Installation Details
 
-The installation is broken up into two different use cases: single and multi-cluster.
-The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
+The installation is broken up into two different use cases: single and multi-cluster. The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
 
-If you are just learning {product_name} the single cluster install is the recommended starting
-point. After which you can move from single cluster to multi-cluster setup down the line.
+If you are just learning {product_name} the single cluster install is the recommended starting point. After which you can move from single cluster to multi-cluster setup down the line.
 
 image::single-cluster.png[Static, 600]
 
@@ -51,14 +49,16 @@ Second install the {product_name} CustomResourcesDefintions.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \\ fleet/fleet-crd
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \
+    fleet/fleet-crd
 ----
 
 Third install the {product_name} controllers.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet \\ fleet/fleet
+helm -n cattle-fleet-system install --create-namespace --wait fleet \
+    fleet/fleet
 ----
 --
 
@@ -66,13 +66,17 @@ Verify::
 +
 --
 {product_name} should be ready to use now for single cluster. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 
@@ -84,17 +88,15 @@ You can now xref:how-tos-for-users/gitrepo-add.adoc[register some git repos] in 
 
 === Deployment
 
-From 0.10 onwards, {product_name} supports static sharding.
-Each shard is defined by its shard ID.
-Optionally, a shard can have a [node
-selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), instructing {product_name} to
-create all controller pods and jobs for that shard on nodes matching that selector.
+From 0.10 onwards, {product_name} supports static sharding. Each shard is defined by its shard ID. Optionally, a shard can have a https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[node selector], instructing {product_name} to create all controller pods and jobs for that shard on nodes matching that selector.
 
 The {product_name} controller chart can be installed with the following arguments:
+
 * `--set shards[$index].id=$shard_id`
 * `--set shards[$index].nodeSelector.$key=$value`
 
 This will result in:
+
 * as many {product_name} controller and gitjob deployments as specified unique shard IDs,
 * plus the usual unsharded {product_name} controller pod. That latter pod will be the only one containing agent management and cleanup containers.
 
@@ -129,11 +131,10 @@ gitjob-shard-foo-8697bb7f67-wzsfj   foo        k3d-upstream-server-0
 
 === How it works
 
-With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the
-unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
+With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
 
-To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a
-value.
+To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a value.
+
 Here is an example:
 
 [,bash]
@@ -152,11 +153,9 @@ spec:
 EOF
 ----
 
-A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be
-processed by that controller.
+A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be processed by that controller.
 
-On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any
-{product_name} controller, hence no resources other than the GitRepo itself will be created.
+On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any {product_name} controller, hence no resources other than the GitRepo itself will be created.
 
 Removing or adding supported shard IDs currently requires redeploying {product_name} with a new set of shard IDs.
 
@@ -171,8 +170,7 @@ The multi-cluster install described below is *only* covered in standalone Fleet,
 
 [IMPORTANT]
 ====
-The setup is the same as for a single cluster.
-After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
+The setup is the same as for a single cluster. After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
 
 However, to allow for xref:how-tos-for-operators/cluster-registration.adoc#_manager_initiated[manager-initiated registration] of downstream clusters, a few extra settings are required. Without the API server URL and the CA, only xref:how-tos-for-operators/cluster-registration.adoc#_agent_initiated[agent-initiated registration] of downstream clusters is possible.
 ====
@@ -180,30 +178,21 @@ However, to allow for xref:how-tos-for-operators/cluster-registration.adoc#_mana
 
 === API Server URL and CA certificate
 
-In order for your {product_name} management installation to properly work it is important
-the correct API server URL and CA certificates are configured properly.  The {product_name} agents
-will communicate to the Kubernetes API server URL. This means the Kubernetes
-API server must be accessible to the downstream clusters.  You will also need
-to obtain the CA certificate of the API server. The easiest way to obtain this information
-is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`,
-`certificate-authority-data`, or `certificate-authority` fields will have these values.
+In order for your {product_name} management installation to properly work it is important the correct API server URL and CA certificates are configured properly.  The {product_name} agents will communicate to the Kubernetes API server URL. This means the Kubernetes API server must be accessible to the downstream clusters.  You will also need to obtain the CA certificate of the API server. The easiest way to obtain this information is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`, `certificate-authority-data`, or `certificate-authority` fields will have these values.
 
 [,yaml]
+.$HOME/.kube/config
 ----
-title="$HOME/.kube/config"
 apiVersion: v1
 clusters:
-
-* cluster:
-  certificate-authority-data: LS0tLS1CRUdJTi...
-  server: https://<EXAMPLE_URL>:6443
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    server: https://example.com:6443
 ----
 
 ==== Extract CA certificate
 
-Please note that the `certificate-authority-data` field is base64 encoded and will need to be
-decoded before you save it into a file. This can be done by saving the base64 encoded contents to
-a file and then running
+Please note that the `certificate-authority-data` field is base64 encoded and will need to be decoded before you save it into a file. This can be done by saving the base64 encoded contents to a file and then running:
 
 [,shell]
 ----
@@ -218,9 +207,10 @@ Extract First::
 +
 --
 If you have `jq` and `base64` available then this one-liners will pull all CA certificates from your `KUBECONFIG` and place then in a file named `ca.pem`.
+
 [,shell]
 ----
-kubectl config view -o json --raw | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 
@@ -228,10 +218,11 @@ Multiple Entries::
 +
 --
 Or, if you have a multi-cluster setup, you can use this command: 
+
 [,shell]
 ----
 # replace CLUSTERNAME with the name of the cluster according to your KUBECONFIG
-kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 ====
@@ -257,22 +248,16 @@ First validate the server URL is correct.
 curl -fLk "$API_SERVER_URL/version"
 ----
 
-The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error.
-If you do not get either of these results than please ensure you have the correct URL. The API server port is typically
-6443 for Kubernetes.
+The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error. If you do not get either of these results than please ensure you have the correct URL. The API server port is typically 6443 for Kubernetes.
 
-Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a
-well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
+Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
 
 [,shell]
 ----
 curl -fL --cacert "$API_SERVER_CA" "$API_SERVER_URL/version"
 ----
 
-If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is
-only because the curl command is not setting proper credentials, but this validates that the TLS
-connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then
-the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
+If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is only because the curl command is not setting proper credentials, but this validates that the TLS connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
 
 [,pem]
 .ca.pem
@@ -289,11 +274,9 @@ KDs/pb3fnMTtpA==
 ----END CERTIFICATE----
 ----
 
-### Install for Multi-Cluster
+=== Install for Multi-Cluster
 
-In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `https://example.com:6443`
-and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can
-omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
+In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `+https://example.com:6443+` and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
 
 Setup the environment with your specific values, e.g.:
 
@@ -303,28 +286,36 @@ API_SERVER_URL="https://example.com:6443"
 API_SERVER_CA="ca.pem"
 ----
 
-Once you have validated the API server URL and API server CA parameters, install the following two
-Helm charts.
+Once you have validated the API server URL and API server CA parameters, install the following two Helm charts.
 
 [tabs]
 ====
 Install::
 +
 --
-First add Fleet's Helm repository. 
+First add Fleet's Helm repository.
+
 [,bash]
 ----
 helm repo add fleet https://rancher.github.io/fleet-helm-charts/
 ----
+
 Second install the {product_name} CustomResourcesDefintions.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ fleet-crd`} {versions.next.fleetCRD}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    fleet-crd fleet/fleet-crd
 ----
+
 Third install the {product_name} controllers.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ --set apiServerURL="$API_SERVER_URL" \\ --set-file apiServerCA="$API_SERVER_CA" \\ fleet`} {versions.next.fleet}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    --set apiServerURL="$API_SERVER_URL" \
+    --set-file apiServerCA="$API_SERVER_CA" \
+    fleet fleet/fleet
 ----
 --
 
@@ -332,16 +323,19 @@ Verify::
 +
 --
 {product_name} should be ready to use. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 ====
 
-At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with
-the {product_name} manager.
+At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with the {product_name} manager.

--- a/versions/v0.11/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
+++ b/versions/v0.11/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
@@ -11,6 +11,7 @@ This leads the status of the bundle and associated GitRepo to be reported as "Mo
 image::ModifiedGitRepo.png[Static, 600]
 
 Associated Bundle
+
 image::ModifiedBundle.png[Static, 600]
 
 {product_name} bundles support the ability to specify a custom http://jsonpatch.com/[jsonPointer patch].

--- a/versions/v0.12/modules/en/pages/bundle-diffs.adoc
+++ b/versions/v0.12/modules/en/pages/bundle-diffs.adoc
@@ -11,6 +11,7 @@ This leads the status of the bundle and associated GitRepo to be reported as "Mo
 image::ModifiedGitRepo.png[Static, 600]
 
 Associated Bundle
+
 image::ModifiedBundle.png[Static, 600]
 
 {product_name} bundles support the ability to specify a custom http://jsonpatch.com/[jsonPointer patch].

--- a/versions/v0.12/modules/en/pages/installation.adoc
+++ b/versions/v0.12/modules/en/pages/installation.adoc
@@ -2,8 +2,7 @@
 
 = Installation Details
 
-The installation is broken up into two different use cases: single and multi-cluster.
-The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
+The installation is broken up into two different use cases: single and multi-cluster. The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
 
 If you are just learning {product_name} the single cluster install is the recommended starting
 point. After which you can move from single cluster to multi-cluster setup down the line.
@@ -51,14 +50,16 @@ Second install the {product_name} CustomResourcesDefintions.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \\ fleet/fleet-crd
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \
+    fleet/fleet-crd
 ----
 
 Third install the {product_name} controllers.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet \\ fleet/fleet
+helm -n cattle-fleet-system install --create-namespace --wait fleet \
+    fleet/fleet
 ----
 --
 
@@ -66,13 +67,17 @@ Verify::
 +
 --
 {product_name} should be ready to use now for single cluster. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 
@@ -84,17 +89,16 @@ You can now xref:./gitrepo-add.adoc[register some git repos] in the `fleet-local
 
 === Deployment
 
-From 0.10 onwards, {product_name} supports static sharding.
-Each shard is defined by its shard ID.
-Optionally, a shard can have a [node
-selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), instructing {product_name} to
-create all controller pods and jobs for that shard on nodes matching that selector.
+From 0.10 onwards, {product_name} supports static sharding. Each shard is defined by its shard ID.
+Optionally, a shard can have a https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[node selector], instructing {product_name} to create all controller pods and jobs for that shard on nodes matching that selector.
 
 The {product_name} controller chart can be installed with the following arguments:
+
 * `--set shards[$index].id=$shard_id`
 * `--set shards[$index].nodeSelector.$key=$value`
 
 This will result in:
+
 * as many {product_name} controller and gitjob deployments as specified unique shard IDs,
 * plus the usual unsharded {product_name} controller pod. That latter pod will be the only one containing agent management and cleanup containers.
 
@@ -129,11 +133,10 @@ gitjob-shard-foo-8697bb7f67-wzsfj   foo        k3d-upstream-server-0
 
 === How it works
 
-With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the
-unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
+With sharding in place, each {product_name} controller will process resources bearing its own shard ID. This also holds for the unsharded controller, which has no set shard ID and will therefore process all unsharded resources.
 
-To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a
-value.
+To deploy a GitRepo for a specific shard, simply add label `fleet.cattle.io/shard-ref` with your desired shard ID as a value.
+
 Here is an example:
 
 [,bash]
@@ -152,11 +155,9 @@ spec:
 EOF
 ----
 
-A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be
-processed by that controller.
+A GitRepo with a label ID for which a {product_name} controller is deployed (eg. `foo` in the above example) will then be processed by that controller.
 
-On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any
-{product_name} controller, hence no resources other than the GitRepo itself will be created.
+On the other hand, a GitRepo with an unknown label ID (eg. `boo` in the above example) will _not_ be processed by any {product_name} controller, hence no resources other than the GitRepo itself will be created.
 
 Removing or adding supported shard IDs currently requires redeploying {product_name} with a new set of shard IDs.
 
@@ -171,8 +172,7 @@ The multi-cluster install described below is *only* covered in standalone Fleet,
 
 [IMPORTANT]
 ====
-The setup is the same as for a single cluster.
-After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
+The setup is the same as for a single cluster. After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
 
 However, to allow for xref:./cluster-registration#_manager_initiated[manager-initiated registration] of downstream clusters, a few extra settings are required. Without the API server URL and the CA, only xref:./cluster-registration#_agent_initiated[agent-initiated registration] of downstream clusters is possible.
 ====
@@ -180,30 +180,21 @@ However, to allow for xref:./cluster-registration#_manager_initiated[manager-ini
 
 === API Server URL and CA certificate
 
-In order for your {product_name} management installation to properly work it is important
-the correct API server URL and CA certificates are configured properly.  The {product_name} agents
-will communicate to the Kubernetes API server URL. This means the Kubernetes
-API server must be accessible to the downstream clusters.  You will also need
-to obtain the CA certificate of the API server. The easiest way to obtain this information
-is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`,
-`certificate-authority-data`, or `certificate-authority` fields will have these values.
+In order for your {product_name} management installation to properly work it is important the correct API server URL and CA certificates are configured properly.  The {product_name} agents will communicate to the Kubernetes API server URL. This means the Kubernetes API server must be accessible to the downstream clusters.  You will also need to obtain the CA certificate of the API server. The easiest way to obtain this information is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`, `certificate-authority-data`, or `certificate-authority` fields will have these values.
 
 [,yaml]
+.$HOME/.kube/config
 ----
-title="$HOME/.kube/config"
 apiVersion: v1
 clusters:
-
-* cluster:
-  certificate-authority-data: LS0tLS1CRUdJTi...
-  server: https://<EXAMPLE_URL>:6443
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    server: https://example.com:6443
 ----
 
 ==== Extract CA certificate
 
-Please note that the `certificate-authority-data` field is base64 encoded and will need to be
-decoded before you save it into a file. This can be done by saving the base64 encoded contents to
-a file and then running
+Please note that the `certificate-authority-data` field is base64 encoded and will need to be decoded before you save it into a file. This can be done by saving the base64 encoded contents to a file and then running:
 
 [,shell]
 ----
@@ -218,9 +209,10 @@ Extract First::
 +
 --
 If you have `jq` and `base64` available then this one-liners will pull all CA certificates from your `KUBECONFIG` and place then in a file named `ca.pem`.
+
 [,shell]
 ----
-kubectl config view -o json --raw | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 
@@ -228,10 +220,11 @@ Multiple Entries::
 +
 --
 Or, if you have a multi-cluster setup, you can use this command: 
+
 [,shell]
 ----
 # replace CLUSTERNAME with the name of the cluster according to your KUBECONFIG
-kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
+kubectl config view -o json --raw  | jq -r '.clusters[] | select(.name=="CLUSTERNAME").cluster["certificate-authority-data"]' | base64 -d > ca.pem
 ----
 --
 ====
@@ -257,22 +250,16 @@ First validate the server URL is correct.
 curl -fLk "$API_SERVER_URL/version"
 ----
 
-The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error.
-If you do not get either of these results than please ensure you have the correct URL. The API server port is typically
-6443 for Kubernetes.
+The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error. If you do not get either of these results than please ensure you have the correct URL. The API server port is typically 6443 for Kubernetes.
 
-Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a
-well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
+Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
 
 [,shell]
 ----
 curl -fL --cacert "$API_SERVER_CA" "$API_SERVER_URL/version"
 ----
 
-If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is
-only because the curl command is not setting proper credentials, but this validates that the TLS
-connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then
-the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
+If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is only because the curl command is not setting proper credentials, but this validates that the TLS connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
 
 [,pem]
 .ca.pem
@@ -291,9 +278,7 @@ KDs/pb3fnMTtpA==
 
 === Install for Multi-Cluster
 
-In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `https://example.com:6443`
-and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can
-omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
+In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `+https://example.com:6443+` and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
 
 Setup the environment with your specific values, e.g.:
 
@@ -303,28 +288,36 @@ API_SERVER_URL="https://example.com:6443"
 API_SERVER_CA="ca.pem"
 ----
 
-Once you have validated the API server URL and API server CA parameters, install the following two
-Helm charts.
+Once you have validated the API server URL and API server CA parameters, install the following two Helm charts.
 
 [tabs]
 ====
 Install::
 +
 --
-First add Fleet's Helm repository. 
+First add Fleet's Helm repository.
+
 [,bash]
 ----
 helm repo add fleet https://rancher.github.io/fleet-helm-charts/
 ----
+
 Second install the {product_name} CustomResourcesDefintions.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ fleet-crd`} {versions.next.fleetCRD}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    fleet-crd fleet/fleet-crd
 ----
+
 Third install the {product_name} controllers.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ --set apiServerURL="$API_SERVER_URL" \\ --set-file apiServerCA="$API_SERVER_CA" \\ fleet`} {versions.next.fleet}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    --set apiServerURL="$API_SERVER_URL" \
+    --set-file apiServerCA="$API_SERVER_CA" \
+    fleet fleet/fleet
 ----
 --
 
@@ -332,16 +325,19 @@ Verify::
 +
 --
 {product_name} should be ready to use. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 ====
 
-At this point the {product_name} manager should be ready. You can now xref:./cluster-registration.adoc[register clusters] and xref:./gitrepo-add.adoc#_create_gitrepo_instance[git repos] with
-the {product_name} manager.
+At this point the {product_name} manager should be ready. You can now xref:./cluster-registration.adoc[register clusters] and xref:./gitrepo-add.adoc#_create_gitrepo_instance[git repos] with the {product_name} manager.

--- a/versions/v0.9/modules/en/pages/how-tos-for-operators/installation.adoc
+++ b/versions/v0.9/modules/en/pages/how-tos-for-operators/installation.adoc
@@ -2,11 +2,9 @@
 
 = Installation Details
 
-The installation is broken up into two different use cases: single and multi-cluster.
-The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
+The installation is broken up into two different use cases: single and multi-cluster. The single cluster install is for if you wish to use GitOps to manage a single cluster, in which case you do not need a centralized manager cluster. In the multi-cluster use case you will setup a centralized manager cluster to which you can register clusters.
 
-If you are just learning {product_name} the single cluster install is the recommended starting
-point. After which you can move from single cluster to multi-cluster setup down the line.
+If you are just learning {product_name} the single cluster install is the recommended starting point. After which you can move from single cluster to multi-cluster setup down the line.
 
 image::single-cluster.png[Static, 600]
 
@@ -51,14 +49,16 @@ Second install the {product_name} CustomResourcesDefintions.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \\ fleet/fleet-crd
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd \
+    fleet/fleet-crd
 ----
 
 Third install the {product_name} controllers.
 
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait fleet \\ fleet/fleet
+helm -n cattle-fleet-system install --create-namespace --wait fleet \
+    fleet/fleet
 ----
 --
 
@@ -66,13 +66,17 @@ Verify::
 +
 --
 {product_name} should be ready to use now for single cluster. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 
@@ -91,8 +95,7 @@ The multi-cluster install described below is *only* covered in standalone Fleet,
 
 [IMPORTANT]
 ====
-The setup is the same as for a single cluster.
-After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
+The setup is the same as for a single cluster. After installing the {product_name} manager, you will then need to register remote downstream clusters with the {product_name} manager.
 
 However, to allow for xref:./cluster-registration#_manager_initiated[manager-initiated registration] of downstream clusters, a few extra settings are required. Without the API server URL and the CA, only xref:./cluster-registration#_agent_initiated[agent-initiated registration] of downstream clusters is possible.
 ====
@@ -100,31 +103,21 @@ However, to allow for xref:./cluster-registration#_manager_initiated[manager-ini
 
 === API Server URL and CA certificate
 
-In order for your {product_name} management installation to properly work it is important
-the correct API server URL and CA certificates are configured properly.  The {product_name} agents
-will communicate to the Kubernetes API server URL. This means the Kubernetes
-API server must be accessible to the downstream clusters.  You will also need
-to obtain the CA certificate of the API server. The easiest way to obtain this information
-is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`,
-`certificate-authority-data`, or `certificate-authority` fields will have these values.
+In order for your {product_name} management installation to properly work it is important the correct API server URL and CA certificates are configured properly.  The {product_name} agents will communicate to the Kubernetes API server URL. This means the Kubernetes API server must be accessible to the downstream clusters.  You will also need to obtain the CA certificate of the API server. The easiest way to obtain this information is typically from your kubeconfig file (`$HOME/.kube/config`). The `server`, `certificate-authority-data`, or `certificate-authority` fields will have these values.
 
 [,yaml]
+.$HOME/.kube/config
 ----
-title="$HOME/.kube/config"
 apiVersion: v1
 clusters:
-
-* cluster:
-  certificate-authority-data: LS0tLS1CRUdJTi...
-  server: https://<EXAMPLE_URL>:6443
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    server: https://example.com:6443
 ----
 
-[discrete]
 ==== Extract CA certificate
 
-Please note that the `certificate-authority-data` field is base64 encoded and will need to be
-decoded before you save it into a file. This can be done by saving the base64 encoded contents to
-a file and then running
+Please note that the `certificate-authority-data` field is base64 encoded and will need to be decoded before you save it into a file. This can be done by saving the base64 encoded contents to a file and then running:
 
 [,shell]
 ----
@@ -139,6 +132,7 @@ Extract First::
 +
 --
 If you have `jq` and `base64` available then this one-liners will pull all CA certificates from your `KUBECONFIG` and place then in a file named `ca.pem`.
+
 [,shell]
 ----
 kubectl config view -o json --raw | jq -r '.clusters[].cluster["certificate-authority-data"]' | base64 -d > ca.pem
@@ -148,7 +142,8 @@ kubectl config view -o json --raw | jq -r '.clusters[].cluster["certificate-auth
 Multiple Entries::
 +
 --
-Or, if you have a multi-cluster setup, you can use this command: 
+Or, if you have a multi-cluster setup, you can use this command:
+
 [,shell]
 ----
 # replace CLUSTERNAME with the name of the cluster according to your KUBECONFIG
@@ -157,7 +152,7 @@ kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="CLUSTERN
 --
 ====
 
-[discrete]
+
 ==== Extract API Server
 
 If you have a multi-cluster setup, you can use this command:
@@ -170,7 +165,7 @@ API_SERVER_URL=$(kubectl config view -o json --raw  | jq -r '.clusters[] | selec
 API_SERVER_CA="ca.pem"
 ----
 
-[discrete]
+
 ==== Validate
 
 First validate the server URL is correct.
@@ -180,22 +175,16 @@ First validate the server URL is correct.
 curl -fLk "$API_SERVER_URL/version"
 ----
 
-The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error.
-If you do not get either of these results than please ensure you have the correct URL. The API server port is typically
-6443 for Kubernetes.
+The output of this command should be JSON with the version of the Kubernetes server or a `401 Unauthorized` error. If you do not get either of these results than please ensure you have the correct URL. The API server port is typically 6443 for Kubernetes.
 
-Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a
-well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
+Next validate that the CA certificate is proper by running the below command.  If your API server is signed by a well known CA then omit the `--cacert "$API_SERVER_CA"` part of the command.
 
 [,shell]
 ----
 curl -fL --cacert "$API_SERVER_CA" "$API_SERVER_URL/version"
 ----
 
-If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is
-only because the curl command is not setting proper credentials, but this validates that the TLS
-connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then
-the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
+If you get a valid JSON response or an `401 Unauthorized` then it worked. The Unauthorized error is only because the curl command is not setting proper credentials, but this validates that the TLS connection work and the `ca.pem` is correct for this URL. If you get a `SSL certificate problem` then the `ca.pem` is not correct. The contents of the `$API_SERVER_CA` file should look similar to the below:
 
 [,pem]
 .ca.pem
@@ -214,9 +203,7 @@ KDs/pb3fnMTtpA==
 
 ### Install for Multi-Cluster
 
-In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `https://example.com:6443`
-and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can
-omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
+In the following example it will be assumed the API server URL from the `KUBECONFIG` which is `+https://example.com:6443+` and the CA certificate is in the file `ca.pem`. If your API server URL is signed by a well-known CA you can omit the `apiServerCA` parameter below or just create an empty `ca.pem` file (ie `touch ca.pem`).
 
 Setup the environment with your specific values, e.g.:
 
@@ -226,8 +213,7 @@ API_SERVER_URL="https://example.com:6443"
 API_SERVER_CA="ca.pem"
 ----
 
-Once you have validated the API server URL and API server CA parameters, install the following two
-Helm charts.
+Once you have validated the API server URL and API server CA parameters, install the following two Helm charts.
 
 [tabs]
 ====
@@ -235,19 +221,28 @@ Install::
 +
 --
 First add Fleet's Helm repository. 
+
 [,bash]
 ----
 helm repo add fleet https://rancher.github.io/fleet-helm-charts/
 ----
+
 Second install the {product_name} CustomResourcesDefintions.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ fleet-crd`} {versions.next.fleetCRD}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    fleet-crd 
 ----
+
 Third install the {product_name} controllers.
+
 [,bash]
 ----
-helm -n cattle-fleet-system install --create-namespace --wait \\ --set apiServerURL="$API_SERVER_URL" \\ --set-file apiServerCA="$API_SERVER_CA" \\ fleet`} {versions.next.fleet}
+helm -n cattle-fleet-system install --create-namespace --wait \
+    --set apiServerURL="$API_SERVER_URL" \
+    --set-file apiServerCA="$API_SERVER_CA" \
+    fleet 
 ----
 --
 
@@ -255,16 +250,19 @@ Verify::
 +
 --
 {product_name} should be ready to use. You can check the status of the {product_name} controller pods by running the below commands.
+
 [,bash]
 ----
-kubectl -n cattle-fleet-system logs -l app=fleet-controller kubectl -n cattle-fleet-system get pods -l app=fleet-controller
+kubectl -n cattle-fleet-system logs -l app=fleet-controller
+kubectl -n cattle-fleet-system get pods -l app=fleet-controller
 ----
+
 [,bash]
 ----
-NAME READY STATUS RESTARTS AGE fleet-controller-64f49d756b-n57wq 1/1 Running 0 3m21s
+NAME                                READY   STATUS    RESTARTS   AGE
+fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 --
 ====
 
-At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with
-the {product_name} manager.
+At this point the {product_name} manager should be ready. You can now xref:how-tos-for-operators/cluster-registration.adoc[register clusters] and xref:how-tos-for-users/gitrepo-add.adoc#_create_gitrepo_instance[git repos] with the {product_name} manager.

--- a/versions/v0.9/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
+++ b/versions/v0.9/modules/en/pages/how-tos-for-users/bundle-diffs.adoc
@@ -8,10 +8,11 @@ The bundled charts may have some objects that are amended at runtime, for exampl
 
 This leads the status of the bundle and associated GitRepo to be reported as "Modified"
 
-image::ModifiedGitRepo.png[]
+image::ModifiedGitRepo.png[Static, 600]
 
 Associated Bundle
-image::ModifiedBundle.png[]
+
+image::ModifiedBundle.png[Static, 600]
 
 {product_name} bundles support the ability to specify a custom http://jsonpatch.com/[jsonPointer patch].
 


### PR DESCRIPTION
Fixing syntax errors for codeblocks from MD conversion, broken links, and unnecessary line breaks for installation.adoc.
Fixing broken image link in bundle-diffs.adoc.
Adding missing `product_name` attribute to next version.