### PR TITLE
Current community docs don't use a 'v' in its version

### DIFF
--- a/fleet-community-local-playbook.yml
+++ b/fleet-community-local-playbook.yml
@@ -1,7 +1,7 @@
 site:
   title: Fleet
   url: /
-  start_page: v0.13@fleet:en:index.adoc
+  start_page: 0.13@fleet:en:index.adoc
 
 content:
   sources:

--- a/fleet-community-remote-playbook.yml
+++ b/fleet-community-remote-playbook.yml
@@ -1,7 +1,7 @@
 site:
   title: Fleet
   url: /
-  start_page: v0.13@fleet:en:index.adoc
+  start_page: 0.13@fleet:en:index.adoc
 
 content:
   sources:

--- a/versions/v0.10/antora-yml/antora-community.yml
+++ b/versions/v0.10/antora-yml/antora-community.yml
@@ -1,7 +1,7 @@
 name: fleet
 title: Fleet
-version: v0.10
-display_version: 'v0.10'
+version: 0.10
+display_version: '0.10'
 start_page: en:index.adoc
 asciidoc:
   attributes:

--- a/versions/v0.11/antora-yml/antora-community.yml
+++ b/versions/v0.11/antora-yml/antora-community.yml
@@ -1,7 +1,7 @@
 name: fleet
 title: Fleet
-version: v0.11
-display_version: 'v0.11'
+version: '0.11'
+display_version: '0.11'
 start_page: en:index.adoc
 asciidoc:
   attributes:

--- a/versions/v0.12/antora-yml/antora-community.yml
+++ b/versions/v0.12/antora-yml/antora-community.yml
@@ -1,7 +1,7 @@
 name: fleet
 title: Fleet
-version: v0.12
-display_version: 'v0.12'
+version: '0.12'
+display_version: '0.12'
 start_page: en:index.adoc
 asciidoc:
   attributes:

--- a/versions/v0.13/antora-yml/antora-community.yml
+++ b/versions/v0.13/antora-yml/antora-community.yml
@@ -1,7 +1,7 @@
 name: fleet
 title: Fleet
-version: v0.13
-display_version: 'v0.13'
+version: '0.13'
+display_version: '0.13'
 start_page: en:index.adoc
 asciidoc:
   attributes:

--- a/versions/v0.9/antora-yml/antora-community.yml
+++ b/versions/v0.9/antora-yml/antora-community.yml
@@ -1,7 +1,7 @@
 name: fleet
 title: Fleet
-version: v0.9
-display_version: 'v0.9'
+version: '0.9'
+display_version: '0.9'
 start_page: en:index.adoc
 asciidoc:
   attributes:


### PR DESCRIPTION
E.g. https://fleet.rancher.io/0.13 does not have a v in its version.