### PR TITLE
Drop '.html' extension from Community URLs

### DIFF
--- a/fleet-community-local-playbook.yml
+++ b/fleet-community-local-playbook.yml
@@ -9,6 +9,9 @@ content:
       start_paths: [versions/v0.13, versions/v0.12,versions/v0.11, versions/v0.10,versions/v0.9]
       branches: HEAD
 
+urls:
+  html_extension_style: drop
+
 # Description: SUSE UI bundle
 ui:
   bundle:

--- a/fleet-community-remote-playbook.yml
+++ b/fleet-community-remote-playbook.yml
@@ -9,6 +9,9 @@ content:
       start_paths: [versions/v0.13, versions/v0.12,versions/v0.11, versions/v0.10,versions/v0.9]
       branches: HEAD
 
+urls:
+  html_extension_style: drop
+
 ui:
   bundle:
     url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true


### PR DESCRIPTION
The Community docs currently don't include the `.html` extension in it's published URLs. E.g. https://fleet.rancher.io/persona