### PR TITLE
Fix formatting of lists in CLI docs

### DIFF
--- a/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_dump.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_dump.adoc
@@ -7,6 +7,7 @@ Dump cluster data into an archive.
 == Overview
 
 Dump data from a cluster into an archive, including:
+
 * Fleet-managed resources
 * Kubernetes events
 * Metrics exposed by Fleet controllers
@@ -30,21 +31,24 @@ fleet dump <flags>
 ==== Contents
 
 The `dump` command produces a `.tgz` archive containing the following data:
+
 * Raw Fleet resources, in YAML format:
-    * Bundles
-    * BundleDeployments
-    * BundleNamespaceMappings
-    * Clusters
-    * ClusterGroups
-    * GitRepos
-    * GitRepoRestrictions
-    * HelmOps
+** Bundles
+** BundleDeployments
+** BundleNamespaceMappings
+** Clusters
+** ClusterGroups
+** GitRepos
+** GitRepoRestrictions
+** HelmOps
+
 * Kubernetes events for the following namespaces:
-    * `cattle-fleet-system`
-    * `cattle-fleet-local-system`
-    * `default`
-    * `kube-system`
-    * each namespace containing a Fleet `Cluster` resource
+** `cattle-fleet-system`
+** `cattle-fleet-local-system`
+** `default`
+** `kube-system`
+** each namespace containing a Fleet `Cluster` resource
+
 * Metrics exposed by `monitoring-*` services living in the `cattle-fleet-system` namespace.
 This typically includes `monitoring-gitjob` and `monitoring-fleet-controller` services, as well as their
 xref:how-tos-for-operators/installation.adoc#multi-controller-install-sharding[sharded] counterparts, if any.

--- a/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_monitor.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_monitor.adoc
@@ -296,16 +296,19 @@ fleet monitor | jq -r '
 A resource is considered "stuck" when:
 
 **Bundle (Generation Mismatch):**
+
 * `generation != observedGeneration` (controller hasn't processed latest spec)
 
 **Note:** Bundles with deletion timestamps are tracked separately as a count in `diagnostics.bundlesWithDeletionTimestamp`.
 
 **BundleDeployment (Stuck):**
+
 * `spec.deploymentID != status.appliedDeploymentID` (agent hasn't applied latest deployment)
 * `syncGeneration` doesn't match `forceSyncGeneration` (forced sync not applied)
 * Has `deletionTimestamp` but still exists
 
 **BundleDeployment (SyncGeneration Mismatch):**
+
 * `syncGeneration` != `forceSyncGeneration` when `forceSyncGeneration > 0` (tracked separately from stuck BundleDeployments)
 
 ==== API Consistency Check


### PR DESCRIPTION
Not all CLI pages were checked, but a few found lists are now rendered more legibly.