### PR TITLE
Fix formatting of sources list for known-hosts entries

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -149,6 +149,7 @@ If no such secret exists, or no `known_hosts` entries are available in that secr
 `known-hosts` config map, newly created at installation time with static entries for the most widely used git providers.
 
 Host key fingerprints added to the config map are sourced, respectively:
+
 * from link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints[GitHub SSH key fingerpints] for
 Github
 * from link:https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries[SSH known host entries] for Gitlab

--- a/community-docs/v0.10/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.10/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -139,6 +139,7 @@ If no such secret exists, or no `known_hosts` entries are available in that secr
 `known-hosts` config map, newly created at installation time with static entries for the most widely used git providers.
 
 Host key fingerprints added to the config map are sourced, respectively:
+
 * from link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints[GitHub SSH key fingerpints] for
 Github
 * from link:https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries[SSH known host entries] for Gitlab

--- a/community-docs/v0.11/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.11/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -140,6 +140,7 @@ If no such secret exists, or no `known_hosts` entries are available in that secr
 `known-hosts` config map, newly created at installation time with static entries for the most widely used git providers.
 
 Host key fingerprints added to the config map are sourced, respectively:
+
 * from link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints[GitHub SSH key fingerpints] for
 Github
 * from link:https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries[SSH known host entries] for Gitlab

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -138,6 +138,7 @@ If no such secret exists, or no `known_hosts` entries are available in that secr
 `known-hosts` config map, newly created at installation time with static entries for the most widely used git providers.
 
 Host key fingerprints added to the config map are sourced, respectively:
+
 * from link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints[GitHub SSH key fingerpints] for
 Github
 * from link:https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries[SSH known host entries] for Gitlab

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -148,6 +148,7 @@ If no such secret exists, or no `known_hosts` entries are available in that secr
 `known-hosts` config map, newly created at installation time with static entries for the most widely used git providers.
 
 Host key fingerprints added to the config map are sourced, respectively:
+
 * from link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints[GitHub SSH key fingerpints] for
 Github
 * from link:https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries[SSH known host entries] for Gitlab

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -149,6 +149,7 @@ If no such secret exists, or no `known_hosts` entries are available in that secr
 `known-hosts` config map, newly created at installation time with static entries for the most widely used git providers.
 
 Host key fingerprints added to the config map are sourced, respectively:
+
 * from link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints[GitHub SSH key fingerpints] for
 Github
 * from link:https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries[SSH known host entries] for Gitlab


### PR DESCRIPTION
A line break is needed for an AsciiDoc list to be rendered with one item per line.