### PR TITLE
Document normalising of replica counts affected by HPA

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/bundle-diffs.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/bundle-diffs.adoc
@@ -354,3 +354,17 @@ diff:
 namespace (in this example in the `consul` namespace) will be ignored.
 
 More information on the supported regex syntax link:https://pkg.go.dev/regexp/syntax[here].
+
+== Horizontal Pod Autoscaling
+
+When dealing with Deployments or StatefulSets referenced by a Horizontal Pod Autoscaler, bundle diffs are no longer
+necessary to address updates in replica counts within the HPA's configured interval.
+The Fleet agent will automatically filter these updates away; as a result, the source bundle deployment will not be
+considered _modified_.
+
+However, if a Deployment or StatefulSet's `replicas` field is set to a value above or below the interval tolerated by an
+HPA referencing it, that modification will still appear in the source bundle deployment's status.
+
+Both `autoscaling/v1` and `autoscaling/v2` are supported.
+
+An empty `minReplicas` field in an HPA will be interpreted as `1`.


### PR DESCRIPTION
Bundle diffs, which would have been an incomplete solution at best, are no longer necessary in such cases.