### PR TITLE
Fix title issues on CLI reference

### DIFF
--- a/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_analyze.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_analyze.adoc
@@ -1,4 +1,4 @@
-== fleet analyze
+= fleet analyze
 :revdate: 2026-02-05
 :page-revdate: {revdate}
 
@@ -9,7 +9,7 @@ Analyze snapshots created by `fleet monitor`
 fleet analyze [flags] MONITOR_FILE
 ----
 
-=== Options
+== Options
 
 [source,text]
 ----
@@ -21,7 +21,7 @@ fleet analyze [flags] MONITOR_FILE
     --no-color     Disable color in output
 ----
 
-=== Usage
+== Usage
 
 [source,bash]
 ----
@@ -52,7 +52,7 @@ fleet analyze --json monitor.json
 fleet analyze --no-color monitor.json
 ----
 
-=== Output Modes
+== Output Modes
 
 - **Summary (default)**: High-level overview of resources and diagnostics
 - **All**: Summary of all snapshots in a multi-snapshot file
@@ -61,7 +61,7 @@ fleet analyze --no-color monitor.json
 - **Detailed**: Complete analysis including controller info, API consistency, and events
 - **JSON**: Machine-readable output for scripts and automation
 
-=== Multi-Snapshot Analysis
+== Multi-Snapshot Analysis
 
 When your monitor.json file contains multiple snapshots (one JSON object per line):
 
@@ -80,7 +80,7 @@ fleet analyze --all monitor.json
 fleet analyze --compare snapshot2.json snapshot1.json
 ----
 
-=== SEE ALSO
+== SEE ALSO
 
 * xref:/reference/cli/fleet-cli/fleet.adoc[fleet]
 * xref:/reference/cli/fleet-cli/fleet_monitor.adoc[fleet monitor]

--- a/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_dump.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_dump.adoc
@@ -1,4 +1,4 @@
-== fleet dump
+= fleet dump
 :revdate: 2026-02-05
 :page-revdate: {revdate}
 
@@ -16,16 +16,16 @@ Dump data from a cluster into an archive, including:
 fleet dump <flags>
 ----
 
-=== Flags
+== Flags
 
 [source,text]
 ----
   -p <path>         Path to the archive file to generate
 ----
 
-=== Output
+== Output
 
-==== Contents
+=== Contents
 
 The `dump` command produces a `.tgz` archive containing the following data:
 
@@ -61,7 +61,7 @@ They contain one event per line, each event being encoded in JSON.
 Metrics are stored into files by service, each file being named `metrics_<service_name>`.
 Their contents are `GET` response bodies received from each service's `/metrics` endpoint, verbatim.
 
-=== SEE ALSO
+== SEE ALSO
 
 * xref:/reference/cli/fleet-cli/fleet.adoc[{product_name}]
 * xref:/reference/cli/fleet-cli/fleet_monitor.adoc[fleet monitor]

--- a/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_monitor.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_monitor.adoc
@@ -1,4 +1,4 @@
-== fleet monitor
+= fleet monitor
 
 Advanced diagnostic tool for troubleshooting  {product_name} deployments.
 

--- a/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_analyze.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_analyze.adoc
@@ -1,4 +1,4 @@
-== fleet analyze
+= fleet analyze
 :revdate: 2026-02-05
 :page-revdate: {revdate}
 
@@ -9,7 +9,7 @@ Analyze snapshots created by `fleet monitor`
 fleet analyze [flags] MONITOR_FILE
 ----
 
-=== Options
+== Options
 
 [source,text]
 ----
@@ -21,7 +21,7 @@ fleet analyze [flags] MONITOR_FILE
     --no-color     Disable color in output
 ----
 
-=== Usage
+== Usage
 
 [source,bash]
 ----
@@ -52,7 +52,7 @@ fleet analyze --json monitor.json
 fleet analyze --no-color monitor.json
 ----
 
-=== Output Modes
+== Output Modes
 
 - **Summary (default)**: High-level overview of resources and diagnostics
 - **All**: Summary of all snapshots in a multi-snapshot file
@@ -61,7 +61,7 @@ fleet analyze --no-color monitor.json
 - **Detailed**: Complete analysis including controller info, API consistency, and events
 - **JSON**: Machine-readable output for scripts and automation
 
-=== Multi-Snapshot Analysis
+== Multi-Snapshot Analysis
 
 When your monitor.json file contains multiple snapshots (one JSON object per line):
 
@@ -80,7 +80,7 @@ fleet analyze --all monitor.json
 fleet analyze --compare snapshot2.json snapshot1.json
 ----
 
-=== SEE ALSO
+== SEE ALSO
 
 * xref:/reference/cli/fleet-cli/fleet.adoc[fleet]
 * xref:/reference/cli/fleet-cli/fleet_monitor.adoc[fleet monitor]

--- a/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_dump.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_dump.adoc
@@ -1,4 +1,4 @@
-== fleet dump
+= fleet dump
 :revdate: 2026-02-05
 :page-revdate: {revdate}
 
@@ -16,33 +16,36 @@ Dump data from a cluster into an archive, including:
 fleet dump <flags>
 ----
 
-=== Flags
+== Flags
 
 [source,text]
 ----
   -p <path>         Path to the archive file to generate
 ----
 
-=== Output
+== Output
 
-==== Contents
+=== Contents
 
 The `dump` command produces a `.tgz` archive containing the following data:
+
 * Raw Fleet resources, in YAML format:
-    * Bundles
-    * BundleDeployments
-    * BundleNamespaceMappings
-    * Clusters
-    * ClusterGroups
-    * GitRepos
-    * GitRepoRestrictions
-    * HelmOps
+** Bundles
+** BundleDeployments
+** BundleNamespaceMappings
+** Clusters
+** ClusterGroups
+** GitRepos
+** GitRepoRestrictions
+** HelmOps
+
 * Kubernetes events for the following namespaces:
-    * `cattle-fleet-system`
-    * `cattle-fleet-local-system`
-    * `default`
-    * `kube-system`
-    * each namespace containing a Fleet `Cluster` resource
+** `cattle-fleet-system`
+** `cattle-fleet-local-system`
+** `default`
+** `kube-system`
+** each namespace containing a Fleet `Cluster` resource
+
 * Metrics exposed by `monitoring-*` services living in the `cattle-fleet-system` namespace.
 This typically includes `monitoring-gitjob` and `monitoring-fleet-controller` services, as well as their
 xref:how-tos-for-operators/installation.adoc#multi-controller-install-sharding[sharded] counterparts, if any.
@@ -58,7 +61,7 @@ They contain one event per line, each event being encoded in JSON.
 Metrics are stored into files by service, each file being named `metrics_<service_name>`.
 Their contents are `GET` response bodies received from each service's `/metrics` endpoint, verbatim.
 
-=== SEE ALSO
+== SEE ALSO
 
 * xref:/reference/cli/fleet-cli/fleet.adoc[{product_name}]
 * xref:/reference/cli/fleet-cli/fleet_monitor.adoc[fleet monitor]

--- a/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_monitor.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_monitor.adoc
@@ -1,4 +1,4 @@
-== fleet monitor
+= fleet monitor
 
 Advanced diagnostic tool for troubleshooting  {product_name} deployments.
 


### PR DESCRIPTION
A page's title must have the topmost header level; failing that, the corresponding section title would not be recognised as the page title, leading the page to be displayed with the default title, in this case `Untitled`.

Refers to #158.