### PR TITLE
Clarify redeployment behaviour with monitoring of downstream resources

### DIFF
--- a/community-docs/next/modules/ROOT/pages/experimental-features/experimental-downstream-resource.adoc
+++ b/community-docs/next/modules/ROOT/pages/experimental-features/experimental-downstream-resource.adoc
@@ -51,3 +51,9 @@ If resources referenced through `downstreamResources` should stay on downstream 
 == Monitoring
 
 From version v0.15.0 onwards, {product_name} monitors changes made to secrets and configmaps that are listed in `DownstreamResources`. It also checks whether a secret or configmap was created after the Bundle was created.
+
+When a referenced secret or configmap is created or updated on the upstream cluster, Fleet will propagate those changes
+to downstream clusters, and re-deploy the workload.
+
+This enables deployments to make use of the latest versions of those referenced resources, which may represent
+configuration, Helm values, etc.


### PR DESCRIPTION
Documentation now clarifies what happens when referenced resources are updated: workloads are re-deployed to make use of those updates.

This also fixes a typo: monitoring of resources referenced as `downstreamResources` is implmemented first in Fleet v0.15.0 (to be released with Rancher v2.14.0).