### PR TITLE
Fix indenting of HelmOps code blocks

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -30,17 +30,17 @@ A ++HelmOp++ resource can be created as follows to start deploying Helm charts d
 apiVersion: fleet.cattle.io/v1alpha1
 kind: HelmOp
 metadata:
-name: my-awesome-helmop
-namespace: "fleet-local"
+  name: my-awesome-helmop
+  namespace: "fleet-local"
 spec:
-helm:
-releaseName: my-fantastic-chart
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: ''
-namespace: that-amazing-namespace
-helmSecretName: my-top-secret-helm-access
-insecureSkipTLSVerify: false
+  helm:
+    releaseName: my-fantastic-chart
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: ''
+  namespace: that-amazing-namespace
+  helmSecretName: my-top-secret-helm-access
+  insecureSkipTLSVerify: false
 ----
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
@@ -55,12 +55,12 @@ Referencing a Helm chart by absolute URL is as simple as providing a URL to a ++
 
 [source,yaml]
 ----
-helm:
-chart: [https://example.com/charts/my-chart-1.2.3.tgz](https://example.com/charts/my-chart-1.2.3.tgz)
-# can be omitted
+  helm:
+    chart: https://example.com/charts/my-chart-1.2.3.tgz
 
-repo: ''
-version: ''
+    # can be omitted
+    repo: ''
+    version: ''
 ----
 
 If a non-empty repo, or a non-empty version is specified in this case, an error will appear in the HelmOp status and no bundle will be created, aborting deployment.
@@ -75,10 +75,10 @@ Example:
 
 [source,yaml]
 ----
-helm:
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: '1.2.3'
+  helm:
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: '1.2.3'
 ----
 
 In this case, only the ++version++ field may be empty. If any of the ++chart++ or ++repo++ field is empty, {product_name} set an error in the HelmOp status and no bundle will be created.
@@ -92,9 +92,9 @@ In this case, Helm options would be similar to this:
 
 [source,yaml]
 ----
-helm:
-repo: oci://foo.bar/baz
-version: '1.2.3' # optional
+  helm:
+    repo: oci://foo.bar/baz
+    version: '1.2.3' # optional
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -45,6 +45,12 @@ spec:
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
 
+[NOTE]
+====
+The `releaseName` field is optional; if not specified, Fleet will derive it from the name of the HelmOp, truncating it
+if needed.
+====
+
 == Supported use cases
 
 With 3 fields available to reference a Helm chart, let's clarify a few rules. As per the Helm install https://helm.sh/docs/helm/helm_install/[documentation], there are 6 ways of expressing a chart to install. 3 of them use either repository aliases or the local filesystem, which are not available in Fleet's HelmOps context. This leaves us with 3 options:

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -30,17 +30,17 @@ A ++HelmOp++ resource can be created as follows to start deploying Helm charts d
 apiVersion: fleet.cattle.io/v1alpha1
 kind: HelmOp
 metadata:
-name: my-awesome-helmop
-namespace: "fleet-local"
+  name: my-awesome-helmop
+  namespace: "fleet-local"
 spec:
-helm:
-releaseName: my-fantastic-chart
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: ''
-namespace: that-amazing-namespace
-helmSecretName: my-top-secret-helm-access
-insecureSkipTLSVerify: false
+  helm:
+    releaseName: my-fantastic-chart
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: ''
+  namespace: that-amazing-namespace
+  helmSecretName: my-top-secret-helm-access
+  insecureSkipTLSVerify: false
 ----
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller will take care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
@@ -55,12 +55,12 @@ Referencing a Helm chart by absolute URL is as simple as providing a URL to a ++
 
 [source,yaml]
 ----
-helm:
-chart: [https://example.com/charts/my-chart-1.2.3.tgz](https://example.com/charts/my-chart-1.2.3.tgz)
-# can be omitted
+  helm:
+    chart: https://example.com/charts/my-chart-1.2.3.tgz
 
-repo: ''
-version: ''
+    # can be omitted
+    repo: ''
+    version: ''
 ----
 
 If a non-empty repo, or a non-empty version is specified in this case, an error will appear in the HelmOp status and no bundle will be created, aborting deployment.
@@ -75,10 +75,10 @@ Example:
 
 [source,yaml]
 ----
-helm:
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: '1.2.3'
+  helm:
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: '1.2.3'
 ----
 
 In this case, only the ++version++ field may be empty. If any of the ++chart++ or ++repo++ field is empty, {product_name} will set an error in the HelmOp status and no bundle will be created.
@@ -92,9 +92,9 @@ In this case, Helm options would be similar to this:
 
 [source,yaml]
 ----
-helm:
-repo: oci://foo.bar/baz
-version: '1.2.3' # optional
+  helm:
+    repo: oci://foo.bar/baz
+    version: '1.2.3' # optional
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -45,6 +45,12 @@ spec:
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller will take care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
 
+[NOTE]
+====
+The `releaseName` field is optional; if not specified, Fleet will derive it from the name of the HelmOp, truncating it
+if needed.
+====
+
 == Supported use cases
 
 With 3 fields available to reference a Helm chart, let's clarify a few rules. As per the Helm install https://helm.sh/docs/helm/helm_install/[documentation], there are 6 ways of expressing a chart to install. 3 of them use either repository aliases or the local filesystem, which are not available in Fleet's HelmOps context. This leaves us with 3 options:

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -30,17 +30,17 @@ A ++HelmOp++ resource can be created as follows to start deploying Helm charts d
 apiVersion: fleet.cattle.io/v1alpha1
 kind: HelmOp
 metadata:
-name: my-awesome-helmop
-namespace: "fleet-local"
+  name: my-awesome-helmop
+  namespace: "fleet-local"
 spec:
-helm:
-releaseName: my-fantastic-chart
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: ''
-namespace: that-amazing-namespace
-helmSecretName: my-top-secret-helm-access
-insecureSkipTLSVerify: false
+  helm:
+    releaseName: my-fantastic-chart
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: ''
+  namespace: that-amazing-namespace
+  helmSecretName: my-top-secret-helm-access
+  insecureSkipTLSVerify: false
 ----
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
@@ -55,12 +55,12 @@ Referencing a Helm chart by absolute URL is as simple as providing a URL to a ++
 
 [source,yaml]
 ----
-helm:
-chart: [https://example.com/charts/my-chart-1.2.3.tgz](https://example.com/charts/my-chart-1.2.3.tgz)
-# can be omitted
+  helm:
+    chart: https://example.com/charts/my-chart-1.2.3.tgz
 
-repo: ''
-version: ''
+    # can be omitted
+    repo: ''
+    version: ''
 ----
 
 If a non-empty repo, or a non-empty version is specified in this case, an error will appear in the HelmOp status and no bundle will be created, aborting deployment.
@@ -75,10 +75,10 @@ Example:
 
 [source,yaml]
 ----
-helm:
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: '1.2.3'
+  helm:
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: '1.2.3'
 ----
 
 In this case, only the ++version++ field may be empty. If any of the ++chart++ or ++repo++ field is empty, {product_name} set an error in the HelmOp status and no bundle will be created.
@@ -92,9 +92,9 @@ In this case, Helm options would be similar to this:
 
 [source,yaml]
 ----
-helm:
-repo: oci://foo.bar/baz
-version: '1.2.3' # optional
+  helm:
+    repo: oci://foo.bar/baz
+    version: '1.2.3' # optional
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -45,6 +45,12 @@ spec:
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
 
+[NOTE]
+====
+The `releaseName` field is optional; if not specified, Fleet will derive it from the name of the HelmOp, truncating it
+if needed.
+====
+
 == Supported use cases
 
 With 3 fields available to reference a Helm chart, let's clarify a few rules. As per the Helm install https://helm.sh/docs/helm/helm_install/[documentation], there are 6 ways of expressing a chart to install. 3 of them use either repository aliases or the local filesystem, which are not available in Fleet's HelmOps context. This leaves us with 3 options:

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -46,6 +46,12 @@ spec:
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
 
+[NOTE]
+====
+The `releaseName` field is optional; if not specified, Fleet will derive it from the name of the HelmOp, truncating it
+if needed.
+====
+
 == Supported use cases
 
 With 3 fields available to reference a Helm chart, let's clarify a few rules. As per the Helm install https://helm.sh/docs/helm/helm_install/[documentation], there are 6 ways of expressing a chart to install. 3 of them use either repository aliases or the local filesystem, which are not available in Fleet's HelmOps context. This leaves us with 3 options:

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -31,17 +31,17 @@ A ++HelmOp++ resource can be created as follows to start deploying Helm charts d
 apiVersion: fleet.cattle.io/v1alpha1
 kind: HelmOp
 metadata:
-name: my-awesome-helmop
-namespace: "fleet-local"
+  name: my-awesome-helmop
+  namespace: "fleet-local"
 spec:
-helm:
-releaseName: my-fantastic-chart
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: ''
-namespace: that-amazing-namespace
-helmSecretName: my-top-secret-helm-access
-insecureSkipTLSVerify: false
+  helm:
+    releaseName: my-fantastic-chart
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: ''
+  namespace: that-amazing-namespace
+  helmSecretName: my-top-secret-helm-access
+  insecureSkipTLSVerify: false
 ----
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
@@ -56,12 +56,12 @@ Referencing a Helm chart by absolute URL is as simple as providing a URL to a ++
 
 [source,yaml]
 ----
-helm:
-chart: [https://example.com/charts/my-chart-1.2.3.tgz](https://example.com/charts/my-chart-1.2.3.tgz)
-# can be omitted
+  helm:
+    chart: https://example.com/charts/my-chart-1.2.3.tgz
 
-repo: ''
-version: ''
+    # can be omitted
+    repo: ''
+    version: ''
 ----
 
 If a non-empty repo, or a non-empty version is specified in this case, an error will appear in the HelmOp status and no bundle will be created, aborting deployment.
@@ -76,10 +76,10 @@ Example:
 
 [source,yaml]
 ----
-helm:
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: '1.2.3'
+  helm:
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: '1.2.3'
 ----
 
 In this case, only the ++version++ field may be empty. If any of the ++chart++ or ++repo++ field is empty, {product_name} set an error in the HelmOp status and no bundle will be created.
@@ -93,9 +93,9 @@ In this case, Helm options would be similar to this:
 
 [source,yaml]
 ----
-helm:
-repo: oci://foo.bar/baz
-version: '1.2.3' # optional
+  helm:
+    repo: oci://foo.bar/baz
+    version: '1.2.3' # optional
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -30,17 +30,17 @@ A ++HelmOp++ resource can be created as follows to start deploying Helm charts d
 apiVersion: fleet.cattle.io/v1alpha1
 kind: HelmOp
 metadata:
-name: my-awesome-helmop
-namespace: "fleet-local"
+  name: my-awesome-helmop
+  namespace: "fleet-local"
 spec:
-helm:
-releaseName: my-fantastic-chart
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: ''
-namespace: that-amazing-namespace
-helmSecretName: my-top-secret-helm-access
-insecureSkipTLSVerify: false
+  helm:
+    releaseName: my-fantastic-chart
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: ''
+  namespace: that-amazing-namespace
+  helmSecretName: my-top-secret-helm-access
+  insecureSkipTLSVerify: false
 ----
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
@@ -55,12 +55,12 @@ Referencing a Helm chart by absolute URL is as simple as providing a URL to a ++
 
 [source,yaml]
 ----
-helm:
-chart: [https://example.com/charts/my-chart-1.2.3.tgz](https://example.com/charts/my-chart-1.2.3.tgz)
-# can be omitted
+  helm:
+    chart: https://example.com/charts/my-chart-1.2.3.tgz
 
-repo: ''
-version: ''
+    # can be omitted
+    repo: ''
+    version: ''
 ----
 
 If a non-empty repo, or a non-empty version is specified in this case, an error will appear in the HelmOp status and no bundle will be created, aborting deployment.
@@ -75,10 +75,10 @@ Example:
 
 [source,yaml]
 ----
-helm:
-repo: [https://foo.bar/baz](https://foo.bar/baz)
-chart: fantastic-chart
-version: '1.2.3'
+  helm:
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: '1.2.3'
 ----
 
 In this case, only the ++version++ field may be empty. If any of the ++chart++ or ++repo++ field is empty, {product_name} set an error in the HelmOp status and no bundle will be created.
@@ -92,9 +92,9 @@ In this case, Helm options would be similar to this:
 
 [source,yaml]
 ----
-helm:
-repo: oci://foo.bar/baz
-version: '1.2.3' # optional
+  helm:
+    repo: oci://foo.bar/baz
+    version: '1.2.3' # optional
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -45,6 +45,12 @@ spec:
 
 For private charts, this requires a Helm access secret (referenced by field ++helmSecretName++) to be created in the same namespace as the ++HelmOp++ resource. The Fleet HelmOps controller takes care of copying that secret to targeted downstream clusters, enabling the Fleet agent to access the registry.
 
+[NOTE]
+====
+The `releaseName` field is optional; if not specified, Fleet will derive it from the name of the HelmOp, truncating it
+if needed.
+====
+
 == Supported use cases
 
 With 3 fields available to reference a Helm chart, let's clarify a few rules. As per the Helm install https://helm.sh/docs/helm/helm_install/[documentation], there are 6 ways of expressing a chart to install. 3 of them use either repository aliases or the local filesystem, which are not available in Fleet's HelmOps context. This leaves us with 3 options:


### PR DESCRIPTION
The migration seems to have made them unreadable.