### PR TITLE
Fix sidebar label for glossary page

### DIFF
--- a/community-docs/next/modules/ROOT/nav.adoc
+++ b/community-docs/next/modules/ROOT/nav.adoc
@@ -12,7 +12,7 @@
 ** xref:explanations/gitrepo-content.adoc[Git Repository Contents]
 ** xref:explanations/namespaces.adoc[Namespaces]
 ** xref:explanations/resources-during-deployment.adoc[Custom Resources During Deployment]
-** xref:explanations/glossary.adoc[Custom Resources During Deployment]
+** xref:explanations/glossary.adoc[Glossary]
 * How-tos for Operators
 ** xref:how-tos-for-operators/installation.adoc[Installation Details]
 ** xref:how-tos-for-operators/cluster-registration.adoc[Register Downstream Clusters]

--- a/community-docs/v0.13/modules/ROOT/nav.adoc
+++ b/community-docs/v0.13/modules/ROOT/nav.adoc
@@ -11,7 +11,7 @@
 ** xref:explanations/gitrepo-content.adoc[Git Repository Contents]
 ** xref:explanations/namespaces.adoc[Namespaces]
 ** xref:explanations/resources-during-deployment.adoc[Custom Resources During Deployment]
-** xref:explanations/glossary.adoc[Custom Resources During Deployment]
+** xref:explanations/glossary.adoc[Glossary]
 
 * How-tos for Operators
 ** xref:how-tos-for-operators/installation.adoc[Installation Details]

--- a/community-docs/v0.14/modules/ROOT/nav.adoc
+++ b/community-docs/v0.14/modules/ROOT/nav.adoc
@@ -12,7 +12,7 @@
 ** xref:explanations/gitrepo-content.adoc[Git Repository Contents]
 ** xref:explanations/namespaces.adoc[Namespaces]
 ** xref:explanations/resources-during-deployment.adoc[Custom Resources During Deployment]
-** xref:explanations/glossary.adoc[Custom Resources During Deployment]
+** xref:explanations/glossary.adoc[Glossary]
 * How-tos for Operators
 ** xref:how-tos-for-operators/installation.adoc[Installation Details]
 ** xref:how-tos-for-operators/cluster-registration.adoc[Register Downstream Clusters]

--- a/community-docs/v0.15/modules/ROOT/nav.adoc
+++ b/community-docs/v0.15/modules/ROOT/nav.adoc
@@ -12,7 +12,7 @@
 ** xref:explanations/gitrepo-content.adoc[Git Repository Contents]
 ** xref:explanations/namespaces.adoc[Namespaces]
 ** xref:explanations/resources-during-deployment.adoc[Custom Resources During Deployment]
-** xref:explanations/glossary.adoc[Custom Resources During Deployment]
+** xref:explanations/glossary.adoc[Glossary]
 * How-tos for Operators
 ** xref:how-tos-for-operators/installation.adoc[Installation Details]
 ** xref:how-tos-for-operators/cluster-registration.adoc[Register Downstream Clusters]


### PR DESCRIPTION
The label was a duplicate from another page.