### PR TITLE
Update steps to get the image pull secret onto downstream clusters

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -291,6 +291,15 @@ For example, to add a secret in kubectl, run
 
 After secret is created, specify the secret to `gitRepo.spec.helmSecretName`. Make sure secret is created under the same namespace with gitrepo.
 
+[NOTE]
+====
+`helmSecretName` only covers authentication for pulling the Helm chart. If the chart deploys workloads whose
+container images are hosted in a private registry, the downstream clusters also need a
+`kubernetes.io/dockerconfigjson` secret to pull those images at runtime. For HelmOps, this can be propagated
+automatically using `downstreamResources`. Refer to
+xref:how-tos-for-users/helm-ops.adoc#_propagating_image_pull_secrets_to_downstream_clusters[Propagating image pull secrets to downstream clusters].
+====
+
 === Use different helm credentials for each path
 
 {product_name} allows you to define unique credentials for each Helm chart path in a Git repository using the helmSecretNameForPaths field.

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-targets.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-targets.adoc
@@ -45,7 +45,7 @@ spec:
   # The name of target. This value is largely for display and logging.
   # If not specified a default name of the format "target000" will be used
   - name: prod
-    # A selector used to match clusters.  The structure is the standard
+    # A selector used to match clusters. The structure is the standard
     # metav1.LabelSelector format. If clusterGroupSelector or clusterGroup is specified,
     # clusterSelector will be used only to further refine the selection after
     # clusterGroupSelector and clusterGroup is evaluated.
@@ -68,11 +68,15 @@ All clusters and cluster groups in the same namespace as the `GitRepo` will be e
 If any of the targets match the cluster then the `GitRepo` will be deployed to the downstream cluster. If
 no match is made, then the `GitRepo` will not be deployed to that cluster.
 
-There are three approaches to matching clusters.
-One can use cluster selectors, cluster group selectors, or an explicit cluster group name.  All criteria is additive so
-the final match is evaluated as "clusterSelector && clusterGroupSelector && clusterGroup".  If any of the three have the
+There are four approaches to matching clusters.
+One can use cluster selectors, cluster group selectors, an explicit cluster group name, or a cluster name.  All criteria is additive so
+the final match is evaluated as "clusterName && clusterSelector && clusterGroupSelector && clusterGroup".  If any of the four have the
 default value it is dropped from the criteria.  The default value is either null or "".  It is important to realize
 that the value `{}` for a selector means "match everything."
+
+When multiple target entries are specified, they are evaluated in order and act as alternatives: if a cluster matches
+the first entry, subsequent entries are not evaluated. This means that entries behave like an OR list, while the
+fields within each entry are still AND'd together.
 
 [,yaml]
 ----
@@ -175,7 +179,7 @@ Configuration management is not limited to deployments but can be expanded to ge
 
 === Limitations when overriding Helm chart settings with `targetCustomizations`
 
-Although `helm.chart`, `helm.repo`, and `helm.version` can be specified in `targetCustomizations`, overriding these fields has important limitations.
+Although `helm.chart`, `helm.repo` and `helm.version` can be specified in `targetCustomizations`, overriding these fields has important limitations.
 
 {product_name} retrieves the Helm chart during the initial **Bundle creation** phase using the top-level `helm` configuration. This retrieval is performed by the Fleet toolchain (`GitJob`) before `targetCustomizations` are processed.
 

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -150,6 +150,42 @@ For more information, refer to xref:how-tos-for-users/gitrepo-add.adoc#_using_pr
 
 The part on using separate credentials for each path is not relevant though, since unlike a GitRepo, a HelmOp resource only references a single Helm chart.
 
+== Propagating image pull secrets to downstream clusters
+
+`helmSecretName` only covers authentication for pulling the Helm chart itself. If the chart deploys workloads
+whose container images are hosted in a private registry, the downstream clusters also need a
+`kubernetes.io/dockerconfigjson` secret to pull those images at runtime.
+
+Create the image pull secret in the same namespace as the `HelmOp` on the upstream cluster:
+
+[source,bash]
+----
+kubectl create secret docker-registry application-collection-secret \
+  -n fleet-local \
+  --docker-server=<registry> \
+  --docker-username=<user> \
+  --docker-password=<password>
+----
+
+Then reference it via `downstreamResources` so {product_name} copies it to each targeted downstream cluster
+before deploying the workload:
+
+[source,yaml]
+----
+spec:
+  helm:
+    values:
+      global:
+        imagePullSecrets:
+          - application-collection-secret
+  downstreamResources:
+    - kind: Secret
+      name: application-collection-secret
+----
+
+For more details on `downstreamResources`, including lifecycle and monitoring behaviour, refer to
+xref:experimental-features/experimental-downstream-resource.adoc[Automatically copying resources to downstream clusters].
+
 == Status updates
 
 Creating a HelmOp resource leads to a bundle being created, if Helm options are valid and a chart version can be found.


### PR DESCRIPTION
nothing in the existing docs explained that chart-pull auth and image-pull auth are separate, or how `downstreamResources` propagates the secret to downstream clusters. Add some lines and adjust a
few minor formatting issues (whitespaces basically)