### PR TITLE
Take downstream resource copy docs out of experimental

### DIFF
--- a/community-docs/next/modules/ROOT/nav.adoc
+++ b/community-docs/next/modules/ROOT/nav.adoc
@@ -31,6 +31,7 @@
 ** xref:how-tos-for-users/rollout.adoc[Rollout Strategy]
 ** xref:how-tos-for-users/helm-ops.adoc[Helm Ops]
 ** xref:how-tos-for-users/fetch-helm-oci.adoc[Fetch Helm Ops]
+** xref:how-tos-for-users/downstream-resource-propagation.adoc[Automated propagation of resources to downstream clusters]
 ** xref:how-tos-for-users/fine-tune-error.adoc[Fine Tuning Error Detection]
 
 * Fleet CLI
@@ -80,7 +81,6 @@
 * Experimental Features
 ** xref:experimental-features/enableexperimental.adoc[Enable Experimental Features]
 ** xref:experimental-features/scheduling.adoc[Scheduling]
-** xref:experimental-features/experimental-downstream-resource.adoc[Automated propagation of resources to downstream clusters]
 ** xref:reference/ref-schedule.adoc[Schedule Resource reference]
 
 * Changelog

--- a/community-docs/next/modules/ROOT/pages/experimental-features/enableexperimental.adoc
+++ b/community-docs/next/modules/ROOT/pages/experimental-features/enableexperimental.adoc
@@ -14,8 +14,6 @@ For more information, refer to Configure xref:reference/ref-configuration.adoc#c
 {product_name} currently supports the following experimental features, toggled through their respective environment variables:
 
 * xref:experimental-features/scheduling.adoc[Scheduling]: `EXPERIMENTAL_SCHEDULES`
-* xref:experimental-features/experimental-downstream-resource.adoc[Automated propagation of resources to downstream
-  clusters]: `EXPERIMENTAL_COPY_RESOURCES_DOWNSTREAM`
 
 == Enabling an experimental feature
 

--- a/community-docs/next/modules/ROOT/pages/explanations/gitrepo-content.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/gitrepo-content.adoc
@@ -340,7 +340,7 @@ These examples showcase the style and format for using `valuesFrom`.
 However, from {product_name} v0.14.0 onwards, they can also be referenced through a HelmOp's `downstreamResources` field to be
 automatically propagated to targeted downstream clusters.
 
-Refer to xref:/experimental-features/experimental-downstream-resource.adoc[experimental downstream resources] for more information.
+Refer to xref:how-tos-for-users/downstream-resource-propagation.adoc[downstream resources propagation] for more information.
 ====
 
 Example ConfigMap:

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/downstream-resource-propagation.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/downstream-resource-propagation.adoc
@@ -1,14 +1,10 @@
 = Automatically copying resources to downstream clusters
-:revdate: 2025-11-04
+:revdate: 2026-06-11
 :page-revdate: {revdate}
-:page-aliases: /experimental-downstream-resource
-
-[WARNING]
-====
-This is an experimental feature.
-====
+:page-aliases: /downstream-resources
 
 From {product_name} v0.14.0 onwards, {product_name} supports propagating external resources to downstream clusters.
+Since v0.16.0, this feature is no longer experimental, and always enabled.
 
 This simplifies dealing with dependencies of charts, such as values coming from external resources.
 See also xref:/explanations/gitrepo-content.adoc#_using_valuesfrom[valuesFrom].

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -184,7 +184,7 @@ spec:
 ----
 
 For more details on `downstreamResources`, including lifecycle and monitoring behaviour, refer to
-xref:experimental-features/experimental-downstream-resource.adoc[Automatically copying resources to downstream clusters].
+xref:how-tos-for-users/downstream-resource-propagation.adoc[Automatically copying resources to downstream clusters].
 
 == Status updates
 

--- a/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
+++ b/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
@@ -162,7 +162,7 @@ You can use the ++fleet monitor++ CLI tool to detect API Time Travel by fetching
 
 *The Implementation:* To copy credentials from the upstream cluster, use the ++downstreamResources++ field in the HelmOps CRD. This dynamically copies existing upstream secrets to downstream clusters before deployment.
 
-* Reference: xref:experimental-features/experimental-downstream-resource.adoc[Experimental Downstream Resources].
+* Reference: xref:how-tos-for-users/downstream-resource-propagation.adoc[Downstream Resources Propagation].
 
 == Drift Management and Edge Deployments
 


### PR DESCRIPTION
Automated copy of resources to downstream clusters is no longer experimental. This commit moves the corresponding documentation from the experimental features section to regular how-tos for users.

Refers to #281.