### PR TITLE
Document best practices for allowed repo patterns

### DIFF
--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -66,9 +66,69 @@ in all namespaces that match `namespaceSelector`. One can specify labels for the
 created bundles from git by putting labels in the `fleet.yaml` file or on the
 `metadata.labels` field on the `GitRepo`.
 
-=== Restricting What Tenants May Do in a Namespace
+=== Restricting GitRepos
 
-A namespace can contain one or more `Policy` resources that restrict which service accounts, credential secrets, and source repositories the `GitRepo`, `HelmOp`, and `Bundle` resources in that namespace may use. Downstream namespace restrictions are not expressed at this layer — they are encoded as RBAC on the tenant's downstream `ServiceAccount`. See xref:explanations/multi-tenancy.adoc[Multi-Tenancy] for the trust model and xref:how-tos-for-operators/tenant-setup.adoc[Tenant Setup] for the operator recipe.
+A namespace can contain multiple `GitRepoRestriction` resources. All `GitRepos`
+created in that namespace will be checked against the list of restrictions. If a
+`GitRepo` violates one of the constraints its `BundleDeployment` will be in an
+error state and won't be deployed.
+
+This can also be used to set the defaults for GitRepo's `serviceAccount` and
+`clientSecretName` fields.
+
+[,yaml]
+----
+kind: GitRepoRestriction
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: restriction
+  namespace: typically-unique
+allowedClientSecretNames: []
+allowedRepoPatterns: []
+allowedServiceAccounts: []
+allowedTargetNamespaces: []
+defaultClientSecretName: ""
+defaultServiceAccount: ""
+----
+
+==== Allowed Target Namespaces
+
+This can be used to limit a deployment to a set of namespaces on a downstream
+cluster. If an allowedTargetNamespaces restriction is present, all `GitRepos`
+must specify a `targetNamespace` and the specified namespace must be in the
+allow list. This also prevents the creation of cluster wide resources.
+
+==== Allowed target namespace selector
+
+`allowedTargetNamespaceSelector` restricts deployments to namespaces on
+downstream clusters whose labels match the given selector. When this field is
+set in a `GitRepoRestriction`, all `GitRepos` must specify a `targetNamespace`.
+The Fleet agent checks the labels of that namespace on the downstream cluster
+before deploying a bundle:
+
+* If the namespace exists and its labels match the selector, deployment proceeds.
+* If the namespace exists but its labels do not match, the `BundleDeployment` is
+* set to an error state and the bundle is not deployed.
+* If the namespace does not exist on the downstream cluster, the deployment fails
+  with an error. Pre-creating the namespace and labelling it correctly is
+  required; Helm's `createNamespace` option does not apply when this selector is
+  set.
+
+Multiple `GitRepoRestriction` resources in the same namespace each contribute
+their `allowedTargetNamespaceSelector`. The selectors are merged before being
+propagated to bundle deployments; a namespace must satisfy all of them.
+
+[source,yaml]
+----
+kind: GitRepoRestriction
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: restriction
+  namespace: workspace1
+allowedTargetNamespaceSelector:
+  matchLabels:
+    team: frontend
+----
 
 == {product_name} Namespaces
 
@@ -101,11 +161,6 @@ Rancher will create two {product_name} workspaces: *fleet-default* and
 registered through Rancher.
 * `fleet-local` will contain the local cluster by default. Access to
 `fleet-local` is limited.
-
-When Rancher creates a workspace:
-
-* Rancher creates a role binding that grants the workspace creator cluster-wide read and write permissions on all {product_name} resources. (The `FleetWorkspace` is a cluster-scoped resource.)
-* Regular users have read and write permissions only on GitRepos and bundles. They have read permissions (get, list, and watch) on the remaining {product_name} resources.
 
 [WARNING] 
 .Important Information

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -204,6 +204,8 @@ allowedTargetNamespaces:
 
 This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
 
+Check out xref:tutorials/best-practices.adoc#_restricting_gitrepo_deployments_multi_tenancy[best practices] for `GitRepoRestrictions`.
+
 == An Example GitRepo Resource
 
 A GitRepo resource created by a tenant, without admin access could look like this:

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
@@ -1,7 +1,7 @@
 = Tenant Setup
 :revdate: 2026-05-21
 :page-revdate: {revdate}
-:page-aliases: /multi-user, /tenant-setup
+:page-aliases:/tenant-setup
 
 This guide applies only to setups where multiple independent teams share a {product_name} manager. If all users are administrators with full trust, none of this is required.
 

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
@@ -1,7 +1,7 @@
 = Tenant Setup
 :revdate: 2026-05-21
 :page-revdate: {revdate}
-:page-aliases: /how-tos-for-operators/multi-user, /multi-user, /tenant-setup
+:page-aliases: /multi-user, /tenant-setup
 
 This guide applies only to setups where multiple independent teams share a {product_name} manager. If all users are administrators with full trust, none of this is required.
 

--- a/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
+++ b/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
@@ -313,6 +313,7 @@ By default, {product_name} stores Kubernetes bundle resources directly in the et
 
 * Reference: xref:reference/ref-crds.adoc[{product_name} CRD Reference].
 
+[#_restricting_gitrepo_deployments_multi_tenancy]
 === Restricting Tenant Deployments (Multi-Tenancy)
 
 *The Best Practice:* In multi-tenant environments, prevent tenants from running deployments with privileged service accounts or pulling from unauthorized repositories.

--- a/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
+++ b/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
@@ -319,4 +319,13 @@ By default, {product_name} stores Kubernetes bundle resources directly in the et
 
 *The Implementation:* Deploy a ++GitRepoRestriction++ CRD. This allows administrators to define whitelists for ++allowedTargetNamespaces++, ++allowedServiceAccounts++, and ++allowedRepoPatterns++.
 
+[NOTE]
+====
+``allowedRepoPatterns`` supports regular expressions which will be matched on a _substring_ basis. This means that an
+expression such as ``\https://example.site/org`` may have more matches than intended, not limited to ``example.site`` hosts.
+
+To mitigate that, you should anchor regular expressions used in ``allowedRepoPatterns``. The above example could become
+``^https://example.site/org``.
+====
+
 * Reference: xref:reference/ref-crd-schema.adoc[{product_name} CRD Schema].


### PR DESCRIPTION
This clarifies that, in GitRepoRestrictions, `allowedRepoPatterns` are matched as substrings, and should be anchored for restricting matches.

Refers to #270.