### PR TITLE
Rename example namespaces to reduce confusion

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
@@ -38,15 +38,15 @@ Both examples below include the cluster resources. Remove them if using the oper
 
 === Stand-alone {product_name}
 
-This creates a tenant whose service account can manage their own resources in namespace `project1`. The `tenant1-policy-read` role is optional — omit it if you prefer tenants not to see the `Policy` directly.
+This creates a tenant whose service account can manage their own resources in namespace `workspace1`. The `tenant1-policy-read` role is optional — omit it if you prefer tenants not to see the `Policy` directly.
 
 [source,bash]
 ----
-kubectl create namespace project1
+kubectl create namespace workspace1
 
 # The ServiceAccount represents the tenant's upstream identity on the management
 # cluster. Co-locating it with the tenant's namespace is cleaner than using 'default'.
-kubectl create serviceaccount tenant1 -n project1
+kubectl create serviceaccount tenant1 -n workspace1
 
 # Tenant gets write access to their own GitRepo / HelmOp / Bundle resources,
 # and to cluster resources if they register their own downstream clusters.
@@ -62,10 +62,10 @@ kubectl create clusterrole tenant1-policy-read \
   --verb=get,list,watch \
   --resource=policies.fleet.cattle.io
 
-kubectl create rolebinding tenant1-write -n project1 \
-  --serviceaccount=project1:tenant1 --clusterrole=tenant1-write
-kubectl create rolebinding tenant1-policy-read -n project1 \
-  --serviceaccount=project1:tenant1 --clusterrole=tenant1-policy-read
+kubectl create rolebinding tenant1-write -n workspace1 \
+  --serviceaccount=workspace1:tenant1 --clusterrole=tenant1-write
+kubectl create rolebinding tenant1-policy-read -n workspace1 \
+  --serviceaccount=workspace1:tenant1 --clusterrole=tenant1-policy-read
 ----
 
 For a second tenant in their own namespace, repeat with a different name and namespace; the two `ClusterRole` objects can be reused.
@@ -79,12 +79,12 @@ In a Rancher-integrated setup, Rancher's own auth provider (local users, LDAP, O
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ---
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
 Then the `GlobalRole`. The `policies` block is optional — see above. The cluster resources follow the same model described above: remove them if the operator manages cluster registration.
@@ -94,9 +94,9 @@ Then the `GlobalRole`. The `policies` block is optional — see above. The clust
 apiVersion: management.cattle.io/v3
 kind: GlobalRole
 metadata:
-  name: fleet-projects1and2
+  name: fleet-workspaces1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -117,7 +117,7 @@ namespacedRules:
         - get
         - list
         - watch
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -142,8 +142,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -168,12 +168,12 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 # Bundles to match by label. The labels are defined in fleet.yaml's labels
 # field or in the GitRepo metadata.labels field.
 bundleSelector:
   matchLabels:
-    tenant: project1
+    tenant: workspace1
 # Namespaces containing clusters, matched by label.
 namespaceSelector:
   matchLabels:
@@ -209,7 +209,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: tenant-1-deploy
-  namespace: project1-workloads
+  namespace: workspace1-workloads
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets"]
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tenant-1-deploy
-  namespace: project1-workloads
+  namespace: workspace1-workloads
 subjects:
   - kind: ServiceAccount
     name: tenant-1-deployer
@@ -236,7 +236,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: tenant-2-deploy
-  namespace: project2-workloads
+  namespace: workspace2-workloads
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets"]
@@ -249,7 +249,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tenant-2-deploy
-  namespace: project2-workloads
+  namespace: workspace2-workloads
 subjects:
   - kind: ServiceAccount
     name: tenant-2-deployer
@@ -310,7 +310,7 @@ kind: Policy
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: tenant-1-policy
-  namespace: project1
+  namespace: workspace1
 requireServiceAccount: true
 allowedServiceAccounts:
   - tenant-1-deployer
@@ -345,9 +345,9 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
-    tenant: project1
+    tenant: workspace1
 spec:
   repo: https://github.com/tenant-1/simpleapp
   paths:

--- a/community-docs/v0.10/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.10/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -34,14 +34,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -49,8 +49,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -63,22 +63,22 @@ For a user to see and deploy fleet resources in a specific workspace, they need 
 * list/get the `fleetworkspace` cluster-wide resource in the local cluster
 * Permissions to create fleet resources (such as `bundles`, `gitrepos`, ...) in the backing namespace for the workspace in the local cluster.
 
-Let's grant permissions to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+Let's grant permissions to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 ifeval::["{product}" == "fleet"]
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
 endif::[]
 
 ifeval::["{product}" == "continuous-delivery"]
 
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
 
 [,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ----
 
 [,yaml]
@@ -86,10 +86,10 @@ metadata:
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
-* Create a `GlobalRole` that grants permission to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+* Create a `GlobalRole` that grants permission to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 [,yaml]
 ----
@@ -98,7 +98,7 @@ kind: GlobalRole
 metadata:
   name: fleet-projects1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -110,7 +110,7 @@ namespacedRules:
         - clustergroups
       verbs:
         - '*'
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -126,8 +126,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -143,7 +143,7 @@ ifeval::["{product}" == "continuous-delivery"]
 Assign the `GlobalRole` to users or groups, more info can be found in the https://documentation.suse.com/cloudnative/rancher-manager/v2.12/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.html#_configuring_global_permissions_for_individual_users[Rancher docs]
 endif::[]
 
-The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `project1` and `project2` workspaces.
+The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `workspace1` and `workspace2` workspaces.
 
 In order to have a well organized environment, each workspace should have its own related `GlobalRole` to help with the separation of duties and isolation required by the customer. This way, each user can be assigned to one or more `GlobalRoles`, depending on the needs.
 
@@ -159,7 +159,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -190,13 +190,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -208,7 +208,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -217,7 +217,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:

--- a/community-docs/v0.11/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.11/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -34,14 +34,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -49,8 +49,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -63,15 +63,15 @@ For a user to see and deploy fleet resources in a specific workspace, they need 
 * list/get the `fleetworkspace` cluster-wide resource in the local cluster
 * Permissions to create fleet resources (such as `bundles`, `gitrepos`, ...) in the backing namespace for the workspace in the local cluster.
 
-Let's grant permissions to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+Let's grant permissions to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 ifeval::["{product}" == "fleet"]
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
 endif::[]
 
 ifeval::["{product}" == "continuous-delivery"]
 
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
 
 endif::[]
 [,yaml]
@@ -79,7 +79,7 @@ endif::[]
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ----
 
 [,yaml]
@@ -87,10 +87,10 @@ metadata:
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
-* Create a `GlobalRole` that grants permission to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+* Create a `GlobalRole` that grants permission to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 [,yaml]
 ----
@@ -99,7 +99,7 @@ kind: GlobalRole
 metadata:
   name: fleet-projects1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -111,7 +111,7 @@ namespacedRules:
         - clustergroups
       verbs:
         - '*'
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -127,8 +127,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -143,7 +143,7 @@ ifeval::["{product}" == "continuous-delivery"]
 
 Assign the `GlobalRole` to users or groups, more info can be found in the https://documentation.suse.com/cloudnative/rancher-manager/v2.12/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.html#_configuring_global_permissions_for_individual_users[Rancher docs]
 endif::[]
-The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `project1` and `project2` workspaces.
+The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `workspace1` and `workspace2` workspaces.
 
 In order to have a well organized environment, each workspace should have its own related `GlobalRole` to help with the separation of duties and isolation required by the customer. This way, each user can be assigned to one or more `GlobalRoles`, depending on the needs.
 
@@ -159,7 +159,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -190,13 +190,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -208,7 +208,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -217,7 +217,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -34,14 +34,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -49,8 +49,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -67,22 +67,22 @@ For a user to see and deploy fleet resources in a specific workspace, they need 
 * list/get the `fleetworkspace` cluster-wide resource in the local cluster
 * Permissions to create fleet resources (such as `bundles`, `gitrepos`, ...) in the backing namespace for the workspace in the local cluster.
 
-Let's grant permissions to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+Let's grant permissions to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 ifeval::["{product}" == "fleet"]
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
 endif::[]
 
 ifeval::["{product}" == "continuous-delivery"]
 
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
 
 [,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ----
 
 [,yaml]
@@ -90,10 +90,10 @@ metadata:
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
-* Create a `GlobalRole` that grants permission to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+* Create a `GlobalRole` that grants permission to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 [,yaml]
 ----
@@ -102,7 +102,7 @@ kind: GlobalRole
 metadata:
   name: fleet-projects1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -114,7 +114,7 @@ namespacedRules:
         - clustergroups
       verbs:
         - '*'
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -130,8 +130,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -147,7 +147,7 @@ ifeval::["{product}" == "continuous-delivery"]
 
 Assign the `GlobalRole` to users or groups, more info can be found in the https://documentation.suse.com/cloudnative/rancher-manager/v2.12/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.html#_configuring_global_permissions_for_individual_users[Rancher docs]
 endif::[]
-The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `project1` and `project2` workspaces.
+The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `workspace1` and `workspace2` workspaces.
 
 In order to have a well organized environment, each workspace should have its own related `GlobalRole` to help with the separation of duties and isolation required by the customer. This way, each user can be assigned to one or more `GlobalRoles`, depending on the needs.
 
@@ -163,7 +163,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -194,13 +194,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -212,7 +212,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -221,7 +221,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -34,14 +34,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -49,8 +49,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -67,15 +67,15 @@ For a user to see and deploy fleet resources in a specific workspace, they need 
 * list/get the `fleetworkspace` cluster-wide resource in the local cluster
 * Permissions to create fleet resources (such as `bundles`, `gitrepos`, ...) in the backing namespace for the workspace in the local cluster.
 
-Let's grant permissions to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+Let's grant permissions to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 ifeval::["{product}" == "fleet"]
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
 endif::[]
 
 ifeval::["{product}" == "continuous-delivery"]
 
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
 
 endif::[]
 [,yaml]
@@ -83,7 +83,7 @@ endif::[]
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ----
 
 [,yaml]
@@ -91,10 +91,10 @@ metadata:
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
-* Create a `GlobalRole` that grants permission to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+* Create a `GlobalRole` that grants permission to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 [,yaml]
 ----
@@ -103,7 +103,7 @@ kind: GlobalRole
 metadata:
   name: fleet-projects1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -115,7 +115,7 @@ namespacedRules:
         - clustergroups
       verbs:
         - '*'
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -131,8 +131,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -148,7 +148,7 @@ ifeval::["{product}" == "continuous-delivery"]
 Assign the `GlobalRole` to users or groups, more info can be found in the https://documentation.suse.com/cloudnative/rancher-manager/v2.12/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.html#_configuring_global_permissions_for_individual_users[Rancher docs]
 endif::[]
 
-The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `project1` and `project2` workspaces.
+The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `workspace1` and `workspace2` workspaces.
 
 In order to have a well organized environment, each workspace should have its own related `GlobalRole` to help with the separation of duties and isolation required by the customer. This way, each user can be assigned to one or more `GlobalRoles`, depending on the needs.
 
@@ -164,7 +164,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -195,13 +195,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -213,7 +213,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -222,7 +222,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -35,14 +35,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -50,8 +50,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -68,15 +68,15 @@ For a user to see and deploy fleet resources in a specific workspace, they need 
 * list/get the `fleetworkspace` cluster-wide resource in the local cluster
 * Permissions to create fleet resources (such as `bundles`, `gitrepos`, ...) in the backing namespace for the workspace in the local cluster.
 
-Let's grant permissions to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+Let's grant permissions to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 ifeval::["{product}" == "fleet"]
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
 endif::[]
 
 ifeval::["{product}" == "continuous-delivery"]
 
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
 
 endif::[]
 [,yaml]
@@ -84,7 +84,7 @@ endif::[]
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ----
 
 [,yaml]
@@ -92,10 +92,10 @@ metadata:
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
-* Create a `GlobalRole` that grants permission to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+* Create a `GlobalRole` that grants permission to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 [,yaml]
 ----
@@ -104,7 +104,7 @@ kind: GlobalRole
 metadata:
   name: fleet-projects1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -116,7 +116,7 @@ namespacedRules:
         - clustergroups
       verbs:
         - '*'
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -132,8 +132,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -149,7 +149,7 @@ ifeval::["{product}" == "continuous-delivery"]
 Assign the `GlobalRole` to users or groups, more info can be found in the https://documentation.suse.com/cloudnative/rancher-manager/v2.12/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.html#_configuring_global_permissions_for_individual_users[Rancher docs]
 endif::[]
 
-The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `project1` and `project2` workspaces.
+The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `workspace1` and `workspace2` workspaces.
 
 In order to have a well organized environment, each workspace should have its own related `GlobalRole` to help with the separation of duties and isolation required by the customer. This way, each user can be assigned to one or more `GlobalRoles`, depending on the needs.
 
@@ -165,7 +165,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -196,13 +196,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -214,7 +214,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -223,7 +223,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:

--- a/community-docs/v0.15/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/explanations/namespaces.adoc
@@ -124,7 +124,7 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 allowedTargetNamespaceSelector:
   matchLabels:
     team: frontend

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -35,14 +35,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -50,8 +50,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -68,15 +68,15 @@ For a user to see and deploy fleet resources in a specific workspace, they need 
 * list/get the `fleetworkspace` cluster-wide resource in the local cluster
 * Permissions to create fleet resources (such as `bundles`, `gitrepos`, ...) in the backing namespace for the workspace in the local cluster.
 
-Let's grant permissions to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+Let's grant permissions to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 ifeval::["{product}" == "fleet"]
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI] or use the following YAML resources:
 endif::[]
 
 ifeval::["{product}" == "continuous-delivery"]
 
-* To create the `project1` and `project2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
+* To create the `workspace1` and `workspace2` fleet workspaces, you can either do it in the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/integrations/fleet/overview.html#_accessing_suse_rancher_prime_continuous_delivery_in_the_rancher_ui[Rancher UI] or use the following YAML resources:
 
 endif::[]
 [,yaml]
@@ -84,7 +84,7 @@ endif::[]
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project1
+  name: workspace1
 ----
 
 [,yaml]
@@ -92,10 +92,10 @@ metadata:
 apiVersion: management.cattle.io/v3
 kind: FleetWorkspace
 metadata:
-  name: project2
+  name: workspace2
 ----
 
-* Create a `GlobalRole` that grants permission to deploy fleet resources in the `project1` and `project2` fleet workspaces:
+* Create a `GlobalRole` that grants permission to deploy fleet resources in the `workspace1` and `workspace2` fleet workspaces:
 
 [,yaml]
 ----
@@ -104,7 +104,7 @@ kind: GlobalRole
 metadata:
   name: fleet-projects1and2
 namespacedRules:
-  project1:
+  workspace1:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -116,7 +116,7 @@ namespacedRules:
         - clustergroups
       verbs:
         - '*'
-  project2:
+  workspace2:
     - apiGroups:
         - fleet.cattle.io
       resources:
@@ -132,8 +132,8 @@ rules:
   - apiGroups:
       - management.cattle.io
     resourceNames:
-      - project1
-      - project2
+      - workspace1
+      - workspace2
     resources:
       - fleetworkspaces
     verbs:
@@ -149,7 +149,7 @@ ifeval::["{product}" == "continuous-delivery"]
 Assign the `GlobalRole` to users or groups, more info can be found in the https://documentation.suse.com/cloudnative/rancher-manager/v2.12/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.html#_configuring_global_permissions_for_individual_users[Rancher docs]
 endif::[]
 
-The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `project1` and `project2` workspaces.
+The user now has access to the `Continuous Delivery` tab in Rancher and can deploy resources to both the `workspace1` and `workspace2` workspaces.
 
 In order to have a well organized environment, each workspace should have its own related `GlobalRole` to help with the separation of duties and isolation required by the customer. This way, each user can be assigned to one or more `GlobalRoles`, depending on the needs.
 
@@ -165,7 +165,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -196,13 +196,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -214,7 +214,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -223,7 +223,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:

--- a/community-docs/v0.9/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.9/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -34,14 +34,14 @@ deploy resources without conflicts.
 
 == Example {product_name} Standalone
 
-This would create a user 'fleetuser', who can only manage GitRepo resources in the 'project1' namespace.
+This would create a user 'fleetuser', who can only manage GitRepo resources in the 'workspace1' namespace.
 
 [,bash]
 ----
  kubectl create serviceaccount fleetuser
- kubectl create namespace project1
- kubectl create -n project1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
+ kubectl create namespace workspace1
+ kubectl create -n workspace1 role fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --role=fleetuser
 ----
 
 If we want to give access to multiple namespaces, we can use a single cluster role with two role bindings:
@@ -49,8 +49,8 @@ If we want to give access to multiple namespaces, we can use a single cluster ro
 [,bash]
 ----
  kubectl create clusterrole fleetuser --verb=get --verb=list --verb=create --verb=delete --resource=gitrepos.fleet.cattle.io
- kubectl create -n project1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
- kubectl create -n project2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace1 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
+ kubectl create -n workspace2 rolebinding fleetuser --serviceaccount=default:fleetuser --clusterrole=fleetuser
 ----
 
 This makes sure, tenants can't interfere with GitRepo resources from other tenants, since they don't have access to their namespaces.
@@ -67,7 +67,7 @@ kind: BundleNamespaceMapping
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: mapping
-  namespace: project1
+  namespace: workspace1
 
 # Bundles to match by label.
 # The labels are defined in the fleet.yaml # labels field or from the
@@ -98,13 +98,13 @@ kind: GitRepoRestriction
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: restriction
-  namespace: project1
+  namespace: workspace1
 
 allowedTargetNamespaces:
-  - project1simpleapp
+  - workspace1simpleapp
 ....
 
-This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'project1simpleapp' namespace.
+This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
 == An Example GitRepo Resource
 
@@ -116,7 +116,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: simpleapp
-  namespace: project1
+  namespace: workspace1
   labels:
     team: one
 
@@ -125,7 +125,7 @@ spec:
   paths:
   - bundle-diffs
 
-  targetNamespace: project1simpleapp
+  targetNamespace: workspace1simpleapp
 
   # do not match the upstream/local cluster, won't work
   targets:


### PR DESCRIPTION
Rancher already provides a `Project` resource [1], which is not related to a workspace. Therefore, naming workspaces `project` may confuse users.

[1]: https://ranchermanager.docs.rancher.com/api/workflows/projects