### PR TITLE
Link to latest release for version from versioned docs

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
@@ -19,7 +19,7 @@ For more information, see xref:how-tos-for-operators/installation.adoc[Install F
 
 == Install Fleet CLI
 
-Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases[Fleet GitHub releases page].
+Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases?q=prerelease%3Afalse&expanded=true[Fleet GitHub releases page].
 
 === Linux/macOS
 

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
@@ -18,7 +18,7 @@ For more information, see xref:how-tos-for-operators/installation.adoc[Install F
 
 == Install Fleet CLI
 
-Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases[Fleet GitHub releases page].
+Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases?q=prerelease%3Afalse+tag%3Av0.12&expanded=true[Fleet GitHub releases page].
 
 === Linux/macOS
 

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
@@ -18,7 +18,7 @@ For more information, see xref:how-tos-for-operators/installation.adoc[Install F
 
 == Install Fleet CLI
 
-Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases[Fleet GitHub releases page].
+Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases?q=prerelease%3Afalse+tag%3Av0.13&expanded=true[Fleet GitHub releases page].
 
 === Linux/macOS
 

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
@@ -19,7 +19,7 @@ For more information, see xref:how-tos-for-operators/installation.adoc[Install F
 
 == Install Fleet CLI
 
-Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases[Fleet GitHub releases page].
+Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases?q=prerelease%3Afalse+tag%3Av0.14&expanded=true[Fleet GitHub releases page].
 
 === Linux/macOS
 

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/install-use-fleet-cli.adoc
@@ -19,7 +19,7 @@ For more information, see xref:how-tos-for-operators/installation.adoc[Install F
 
 == Install Fleet CLI
 
-Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases[Fleet GitHub releases page].
+Fleet CLI is a stand-alone binary that you can download from the link:https://github.com/rancher/fleet/releases?q=prerelease%3Afalse+tag%3Av0.15&expanded=true[Fleet GitHub releases page].
 
 === Linux/macOS
 


### PR DESCRIPTION
Versioned installation instructions for the Fleet CLI now link to the latest release for the corresponding version. By the same token, pre-release versions are no longer included in results.