### PR TITLE
Replace `{product_name}` tags with `Fleet` in code blocks

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
@@ -23,7 +23,7 @@ Use the `ignore.conditions` setting in the `fleet.yaml` file to tell {product_na
 ----
 # from ref-fleet-yaml
 
-# Ignore fields when monitoring a Bundle. This can be used when {product_name} thinks
+# Ignore fields when monitoring a Bundle. This can be used when Fleet thinks
 # some conditions in Custom Resources makes the Bundle to be in an error state
 # when it shouldn't.
 ignore:

--- a/community-docs/next/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -82,14 +82,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/next/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -129,8 +129,8 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be created beforehand,
   # for instance coming from another git repo registered with
-  # the {product_name} manager.
-  # If no service account is configured, {product_name} checks for a service account
+  # the Fleet manager.
+  # If no service account is configured, Fleet checks for a service account
   # named "fleet-default".
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin

--- a/community-docs/v0.10/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.10/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -81,14 +81,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.10/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.10/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -110,11 +110,11 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be create before
   # hand, most likely coming from another git repo registered with
-  # the {product_name} manager.
+  # the Fleet manager.
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   # If empty, the "default" cluster group is used.

--- a/community-docs/v0.11/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.11/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -81,14 +81,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.11/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.11/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -110,11 +110,11 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be create before
   # hand, most likely coming from another git repo registered with
-  # the {product_name} manager.
+  # the Fleet manager.
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   # If empty, the "default" cluster group is used.

--- a/community-docs/v0.12/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -81,14 +81,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.12/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -128,8 +128,8 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be created beforehand,
   # for instance coming from another git repo registered with
-  # the {product_name} manager.
-  # If no service account is configured, {product_name} checks for a service account
+  # the Fleet manager.
+  # If no service account is configured, Fleet checks for a service account
   # named "fleet-default".
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
@@ -22,7 +22,7 @@ Use the `ignore.conditions` setting in the `fleet.yaml` file to tell {product_na
 ----
 # from ref-fleet-yaml
 
-# Ignore fields when monitoring a Bundle. This can be used when {product_name} thinks
+# Ignore fields when monitoring a Bundle. This can be used when Fleet thinks
 # some conditions in Custom Resources makes the Bundle to be in an error state
 # when it shouldn't.
 ignore:

--- a/community-docs/v0.13/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -81,14 +81,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.13/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -128,8 +128,8 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be created beforehand,
   # for instance coming from another git repo registered with
-  # the {product_name} manager.
-  # If no service account is configured, {product_name} checks for a service account
+  # the Fleet manager.
+  # If no service account is configured, Fleet checks for a service account
   # named "fleet-default".
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
@@ -23,7 +23,7 @@ Use the `ignore.conditions` setting in the `fleet.yaml` file to tell {product_na
 ----
 # from ref-fleet-yaml
 
-# Ignore fields when monitoring a Bundle. This can be used when {product_name} thinks
+# Ignore fields when monitoring a Bundle. This can be used when Fleet thinks
 # some conditions in Custom Resources makes the Bundle to be in an error state
 # when it shouldn't.
 ignore:

--- a/community-docs/v0.14/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -82,14 +82,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.14/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -129,8 +129,8 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be created beforehand,
   # for instance coming from another git repo registered with
-  # the {product_name} manager.
-  # If no service account is configured, {product_name} checks for a service account
+  # the Fleet manager.
+  # If no service account is configured, Fleet checks for a service account
   # named "fleet-default".
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/fine-tune-error.adoc
@@ -23,7 +23,7 @@ Use the `ignore.conditions` setting in the `fleet.yaml` file to tell {product_na
 ----
 # from ref-fleet-yaml
 
-# Ignore fields when monitoring a Bundle. This can be used when {product_name} thinks
+# Ignore fields when monitoring a Bundle. This can be used when Fleet thinks
 # some conditions in Custom Resources makes the Bundle to be in an error state
 # when it shouldn't.
 ignore:

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -82,14 +82,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -129,8 +129,8 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be created beforehand,
   # for instance coming from another git repo registered with
-  # the {product_name} manager.
-  # If no service account is configured, {product_name} checks for a service account
+  # the Fleet manager.
+  # If no service account is configured, Fleet checks for a service account
   # named "fleet-default".
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin

--- a/community-docs/v0.9/modules/ROOT/pages/reference/ref-bundle.adoc
+++ b/community-docs/v0.9/modules/ROOT/pages/reference/ref-bundle.adoc
@@ -81,14 +81,14 @@ spec:
                   - containerPort: 80
     name: nginx.yaml
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   #
   # targets: ...
 
-  # This field is used by {product_name} internally, and it should not be modified manually.
-  # {product_name} will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
+  # This field is used by Fleet internally, and it should not be modified manually.
+  # Fleet will copy all targets into targetRestrictions when a Bundle is created for a GitRepo.
   # targetRestrictions: ...
 
   # Refers to the bundles which must be ready before this bundle can be deployed.

--- a/community-docs/v0.9/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.9/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -198,7 +198,7 @@ targetCustomizations:
   clusterSelector:
     matchLabels:
       env: prod
-  # A selector used to match a specific cluster by name. When using {product_name} in
+  # A selector used to match a specific cluster by name. When using Fleet in
   # Rancher, make sure to put the name of the clusters.fleet.cattle.io resource.
   clusterName: dev-cluster
   # A selector used to match cluster groups.
@@ -223,7 +223,7 @@ dependsOn:
       matchLabels:
         app: weak-monkey
 
-# Ignore fields when monitoring a Bundle. This can be used when {product_name} thinks some conditions in Custom Resources
+# Ignore fields when monitoring a Bundle. This can be used when Fleet thinks some conditions in Custom Resources
 # makes the Bundle to be in an error state when it shouldn't.
 ignore:
   # Conditions to be ignored

--- a/community-docs/v0.9/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.9/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -102,11 +102,11 @@ spec:
   # downstream cluster in the cattle-fleet-system namespace. It is assumed
   # this service account already exists so it should be create before
   # hand, most likely coming from another git repo registered with
-  # the {product_name} manager.
+  # the Fleet manager.
   #
   # serviceAccount: moreSecureAccountThanClusterAdmin
 
-  # Target clusters to deploy to if running {product_name} in a multi-cluster
+  # Target clusters to deploy to if running Fleet in a multi-cluster
   # style. Refer to the "Mapping to Downstream Clusters" docs for
   # more information.
   # If empty, the "default" cluster group is used.


### PR DESCRIPTION
The `{product_name}` placeholder does not seem to be rendered in code blocks, and is left as-is.