### PR TITLE
Clarify RBAC stemming from FleetWorkspace creation

### DIFF
--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -102,6 +102,13 @@ registered through Rancher.
 * `fleet-local` will contain the local cluster by default. Access to
 `fleet-local` is limited.
 
+When Rancher creates a workspace, the following happens:
+
+* Rancher creates a role binding which grants the workspace creator cluster-wide read and write permissions on all Fleet
+  resources (a `FleetWorkspace` is a cluster-scoped resource)
+* Regular users, however, will have read/write permissions only on GitRepos and bundles, and read (get/list/watch)
+  permissions on remaining Fleet resources.
+
 [WARNING] 
 .Important Information
 ====

--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -102,12 +102,10 @@ registered through Rancher.
 * `fleet-local` will contain the local cluster by default. Access to
 `fleet-local` is limited.
 
-When Rancher creates a workspace, the following happens:
+When Rancher creates a workspace:
 
-* Rancher creates a role binding which grants the workspace creator cluster-wide read and write permissions on all Fleet
-  resources (a `FleetWorkspace` is a cluster-scoped resource)
-* Regular users, however, will have read/write permissions only on GitRepos and bundles, and read (get/list/watch)
-  permissions on remaining Fleet resources.
+* Rancher creates a role binding that grants the workspace creator cluster-wide read and write permissions on all {product_name} resources. (The `FleetWorkspace` is a cluster-scoped resource.)
+* Regular users have read and write permissions only on GitRepos and bundles. They have read permissions (get, list, and watch) on the remaining {product_name} resources.
 
 [WARNING] 
 .Important Information


### PR DESCRIPTION
Read/write permissions on all Fleet resources only apply to the workspace creator.

Refers to #293.