### PR TITLE
Update helmRepoURLRegex documentation

### DIFF
--- a/community-docs/next/modules/ROOT/assets/attachments/crds/gitrepo_v1alpha1.json
+++ b/community-docs/next/modules/ROOT/assets/attachments/crds/gitrepo_v1alpha1.json
@@ -80,7 +80,7 @@
           "type": "integer"
         },
         "helmRepoURLRegex": {
-          "description": "HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex\nCredentials will always be used if this is empty or not provided.",
+          "description": "HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex\nCredentials will not be used if this is empty or not provided.",
           "nullable": true,
           "type": "string"
         },

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -254,8 +254,8 @@ endif::[]
 
 [CAUTION]
 ====
-The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
-Make sure you don't leak credentials by mixing public and private repositories. Use <<Use different helm credentials for each path,different helm credentials for each path>>, or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
+Helm credentials are forwarded only when `helmRepoURLRegex` is set and matches the Helm repository URL.
+Use specific `helmRepoURLRegex` patterns so credentials are only forwarded to trusted Helm repository URLs. You can also use <<Use different helm credentials for each path,different helm credentials for each path>> or split charts into different gitrepos.
 ====
 
 

--- a/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
@@ -27,7 +27,7 @@ fleet apply [flags] BUNDLE_NAME PATH...
       --delete-namespace                       Delete GitRepo target namespace after the GitRepo or Bundle is deleted
   -f, --file string                            Location of the fleet.yaml
       --helm-credentials-by-path-file string   Path of file containing helm credentials for paths
-      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided
+      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will not be used if this is empty or not provided
   -h, --help                                   help for apply
       --keep-resources                         Keep resources created after the GitRepo or Bundle is deleted
   -k, --kubeconfig string                      kubeconfig for authentication

--- a/community-docs/next/modules/ROOT/pages/reference/ref-crds.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-crds.adoc
@@ -2316,7 +2316,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | false
 
 | helmRepoURLRegex
-| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will always be used if this is empty or not provided.
+| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will not be used if this is empty or not provided.
 | string
 | false
 

--- a/community-docs/next/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -54,15 +54,15 @@ spec:
 
   # If fleet.yaml contains a private Helm repo that requires authentication,
   # provide the credentials in a K8s secret and specify them here.
-  # Danger: the credentials will be sent to all repositories referenced from
-  # this gitrepo. See section below for more information.
+  # Helm credentials are forwarded only when helmRepoURLRegex matches the
+  # Helm repository URL. See section below for more information.
   #
   # helmSecretName: my-helm-secret
 
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
-  # Credentials will always be used if it is empty or not provided
+  # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts\.rancher\.io/
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/next/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -62,7 +62,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts\.rancher\.io/
+  # helmRepoURLRegex: https://charts\.rancher\.io(/|$)
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
@@ -29,12 +29,13 @@ Some of them can be automated through xref:reference/cli/fleet-cli/fleet_monitor
 
 In the local management cluster where the `fleet-controller` is deployed, run the following command with your specific `fleet-controller` pod name filled in:
 
- $ kubectl logs -l app=fleet-controller -n cattle-fleet-system
+ `$ kubectl logs -l app=fleet-controller -n cattle-fleet-system`
 
 === Fetch the log from the `fleet-agent`?
 
 Go to each downstream cluster and run the following command for the local cluster with your specific `fleet-agent` pod name filled in:
 
+[source,bash]
 ----
 # Downstream cluster
 $ kubectl logs -l app=fleet-agent -n cattle-fleet-system
@@ -79,13 +80,13 @@ Check the xref:troubleshooting.adoc#_fetch_the_log_from_fleet_controller[`fleet-
 
 Check the `gitjob-controller` logs using the following command with your specific `gitjob` pod name filled in:
 
- $ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system
+`$ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system`
 
 Note that there are two containers inside the pod: the `step-git-source` container that clones the git repo, and the `fleet` container that applies bundles based on the git repo.
 
 The pods will usually have images named `rancher/tekton-utils` with the `gitRepo` name as a prefix. Check the logs for these Kubernetes job pods in the local management cluster as follows, filling in your specific `gitRepoName` pod name and namespace:
 
- $ kubectl logs -f $gitRepoName-pod-name -n namespace
+ `$ kubectl logs -f $gitRepoName-pod-name -n namespace`
 
 === Check the status of the `fleet-controller`?
 
@@ -177,6 +178,7 @@ endif::[]
 
 If your GitJob returns the error below, the problem may be that {product_name} cannot access the Helm repo you specified in your xref:reference/ref-fleet-yaml.adoc[`fleet.yaml`]:
 
+[source,text]
 ----
 time="2021-11-04T09:21:24Z" level=fatal msg="bad response code: 403"
 ----
@@ -192,6 +194,7 @@ If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex`
 
 When this happens, {product_name} logs a warning similar to:
 
+[source,text]
 ----
 helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
 ----
@@ -206,6 +209,7 @@ To fix this issue:
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:
 
+[source,text]
 ----
 time="2021-11-11T05:55:08Z" level=fatal msg="Get \"https://helm.intra/virtual-helm/index.yaml\": x509: certificate signed by unknown authority"
 ----

--- a/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
@@ -199,7 +199,7 @@ helmRepoURLRegex is empty: Helm credentials will not be forwarded to any reposit
 To fix this issue:
 
 * Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
-* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com(/|$)`
 * If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
 
 === Helm chart repo: certificate signed by unknown authority

--- a/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
@@ -186,6 +186,22 @@ Perform the following steps to assess:
 * Check that your repo is accessible from your dev machine, and that you can download the Helm chart successfully
 * Check that your credentials for the git repo are valid
 
+=== Helm credentials are not forwarded when `helmRepoURLRegex` is empty
+
+If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex` is empty, {product_name} does not forward those credentials to Helm repositories.
+
+When this happens, {product_name} logs a warning similar to:
+
+----
+helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
+----
+
+To fix this issue:
+
+* Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
+
 === Helm chart repo: certificate signed by unknown authority
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -196,8 +196,8 @@ endif::[]
 
 [CAUTION]
 ====
-The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
-Make sure you don't leak credentials by mixing public and private repositories. Use <<Use different helm credentials for each path,different helm credentials for each path>>, or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
+Helm credentials are forwarded only when `helmRepoURLRegex` is set and matches the Helm repository URL.
+Use specific `helmRepoURLRegex` patterns so credentials are only forwarded to trusted Helm repository URLs. You can also use <<Use different helm credentials for each path,different helm credentials for each path>> or split charts into different gitrepos.
 ====
 
 

--- a/community-docs/v0.12/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
@@ -24,7 +24,7 @@ fleet apply [flags] BUNDLE_NAME PATH...
       --delete-namespace                       Delete GitRepo target namespace after the GitRepo or Bundle is deleted
   -f, --file string                            Location of the fleet.yaml
       --helm-credentials-by-path-file string   Path of file containing helm credentials for paths
-      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided
+      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will not be used if this is empty or not provided
   -h, --help                                   help for apply
       --keep-resources                         Keep resources created after the GitRepo or Bundle is deleted
   -k, --kubeconfig string                      kubeconfig for authentication

--- a/community-docs/v0.12/modules/ROOT/pages/reference/ref-crds.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/ref-crds.adoc
@@ -2306,7 +2306,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | false
 
 | helmRepoURLRegex
-| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will always be used if this is empty or not provided.
+| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will not be used if this is empty or not provided.
 | string
 | false
 

--- a/community-docs/v0.12/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -53,15 +53,15 @@ spec:
 
   # If fleet.yaml contains a private Helm repo that requires authentication,
   # provide the credentials in a K8s secret and specify them here.
-  # Danger: the credentials will be sent to all repositories referenced from
-  # this gitrepo. See section below for more information.
+  # Helm credentials are forwarded only when helmRepoURLRegex matches the
+  # Helm repository URL. See section below for more information.
   #
   # helmSecretName: my-helm-secret
 
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
-  # Credentials will always be used if it is empty or not provided
+  # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts\.rancher\.io/
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.12/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -61,7 +61,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts\.rancher\.io/
+  # helmRepoURLRegex: https://charts\.rancher\.io(/|$)
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.12/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/troubleshooting.adoc
@@ -27,12 +27,13 @@ The next section explains how to run all these checks.
 
 In the local management cluster where the `fleet-controller` is deployed, run the following command with your specific `fleet-controller` pod name filled in:
 
- $ kubectl logs -l app=fleet-controller -n cattle-fleet-system
+ `$ kubectl logs -l app=fleet-controller -n cattle-fleet-system`
 
 === Fetch the log from the `fleet-agent`?
 
 Go to each downstream cluster and run the following command for the local cluster with your specific `fleet-agent` pod name filled in:
 
+[source,bash]
 ----
 # Downstream cluster
 $ kubectl logs -l app=fleet-agent -n cattle-fleet-system
@@ -77,13 +78,13 @@ Check the xref:troubleshooting.adoc#_fetch_the_log_from_fleet_controller[`fleet-
 
 Check the `gitjob-controller` logs using the following command with your specific `gitjob` pod name filled in:
 
- $ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system
+ `$ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system`
 
 Note that there are two containers inside the pod: the `step-git-source` container that clones the git repo, and the `fleet` container that applies bundles based on the git repo.
 
 The pods will usually have images named `rancher/tekton-utils` with the `gitRepo` name as a prefix. Check the logs for these Kubernetes job pods in the local management cluster as follows, filling in your specific `gitRepoName` pod name and namespace:
 
- $ kubectl logs -f $gitRepoName-pod-name -n namespace
+ `$ kubectl logs -f $gitRepoName-pod-name -n namespace`
 
 === Check the status of the `fleet-controller`?
 
@@ -136,6 +137,7 @@ endif::[]
 
 If your GitJob returns the error below, the problem may be that {product_name} cannot access the Helm repo you specified in your xref:reference/ref-fleet-yaml.adoc[`fleet.yaml`]:
 
+[source,text]
 ----
 time="2021-11-04T09:21:24Z" level=fatal msg="bad response code: 403"
 ----
@@ -151,6 +153,7 @@ If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex`
 
 When this happens, {product_name} logs a warning similar to:
 
+[source,text]
 ----
 helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
 ----
@@ -165,6 +168,7 @@ To fix this issue:
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:
 
+[source,text]
 ----
 time="2021-11-11T05:55:08Z" level=fatal msg="Get \"https://helm.intra/virtual-helm/index.yaml\": x509: certificate signed by unknown authority"
 ----

--- a/community-docs/v0.12/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/troubleshooting.adoc
@@ -145,6 +145,22 @@ Perform the following steps to assess:
 * Check that your repo is accessible from your dev machine, and that you can download the Helm chart successfully
 * Check that your credentials for the git repo are valid
 
+=== Helm credentials are not forwarded when `helmRepoURLRegex` is empty
+
+If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex` is empty, {product_name} does not forward those credentials to Helm repositories.
+
+When this happens, {product_name} logs a warning similar to:
+
+----
+helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
+----
+
+To fix this issue:
+
+* Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
+
 === Helm chart repo: certificate signed by unknown authority
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:

--- a/community-docs/v0.12/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/troubleshooting.adoc
@@ -158,7 +158,7 @@ helmRepoURLRegex is empty: Helm credentials will not be forwarded to any reposit
 To fix this issue:
 
 * Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
-* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com(/|$)`
 * If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
 
 === Helm chart repo: certificate signed by unknown authority

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -259,8 +259,8 @@ endif::[]
 
 [CAUTION]
 ====
-The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
-Make sure you don't leak credentials by mixing public and private repositories. Use <<Use different helm credentials for each path,different helm credentials for each path>>, or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
+Helm credentials are forwarded only when `helmRepoURLRegex` is set and matches the Helm repository URL.
+Use specific `helmRepoURLRegex` patterns so credentials are only forwarded to trusted Helm repository URLs. You can also use <<Use different helm credentials for each path,different helm credentials for each path>> or split charts into different gitrepos.
 ====
 
 

--- a/community-docs/v0.13/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
@@ -24,7 +24,7 @@ fleet apply [flags] BUNDLE_NAME PATH...
       --delete-namespace                       Delete GitRepo target namespace after the GitRepo or Bundle is deleted
   -f, --file string                            Location of the fleet.yaml
       --helm-credentials-by-path-file string   Path of file containing helm credentials for paths
-      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided
+      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will not be used if this is empty or not provided
   -h, --help                                   help for apply
       --keep-resources                         Keep resources created after the GitRepo or Bundle is deleted
   -k, --kubeconfig string                      kubeconfig for authentication

--- a/community-docs/v0.13/modules/ROOT/pages/reference/ref-crds.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/ref-crds.adoc
@@ -2306,7 +2306,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | false
 
 | helmRepoURLRegex
-| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will always be used if this is empty or not provided.
+| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will not be used if this is empty or not provided.
 | string
 | false
 

--- a/community-docs/v0.13/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -53,15 +53,15 @@ spec:
 
   # If fleet.yaml contains a private Helm repo that requires authentication,
   # provide the credentials in a K8s secret and specify them here.
-  # Danger: the credentials will be sent to all repositories referenced from
-  # this gitrepo. See section below for more information.
+  # Helm credentials are forwarded only when helmRepoURLRegex matches the
+  # Helm repository URL. See section below for more information.
   #
   # helmSecretName: my-helm-secret
 
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
-  # Credentials will always be used if it is empty or not provided
+  # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts\.rancher\.io/
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.13/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -61,7 +61,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts\.rancher\.io/
+  # helmRepoURLRegex: https://charts\.rancher\.io(/|$)
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.13/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/troubleshooting.adoc
@@ -197,7 +197,7 @@ helmRepoURLRegex is empty: Helm credentials will not be forwarded to any reposit
 To fix this issue:
 
 * Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
-* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com(/|$)`
 * If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
 
 === Helm chart repo: certificate signed by unknown authority

--- a/community-docs/v0.13/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/troubleshooting.adoc
@@ -27,12 +27,13 @@ The next section explains how to run all these checks.
 
 In the local management cluster where the `fleet-controller` is deployed, run the following command with your specific `fleet-controller` pod name filled in:
 
- $ kubectl logs -l app=fleet-controller -n cattle-fleet-system
+ `$ kubectl logs -l app=fleet-controller -n cattle-fleet-system`
 
 === Fetch the log from the `fleet-agent`?
 
 Go to each downstream cluster and run the following command for the local cluster with your specific `fleet-agent` pod name filled in:
 
+[source,bash]
 ----
 # Downstream cluster
 $ kubectl logs -l app=fleet-agent -n cattle-fleet-system
@@ -77,13 +78,13 @@ Check the xref:troubleshooting.adoc#_fetch_the_log_from_fleet_controller[`fleet-
 
 Check the `gitjob-controller` logs using the following command with your specific `gitjob` pod name filled in:
 
- $ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system
+ `$ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system`
 
 Note that there are two containers inside the pod: the `step-git-source` container that clones the git repo, and the `fleet` container that applies bundles based on the git repo.
 
 The pods will usually have images named `rancher/tekton-utils` with the `gitRepo` name as a prefix. Check the logs for these Kubernetes job pods in the local management cluster as follows, filling in your specific `gitRepoName` pod name and namespace:
 
- $ kubectl logs -f $gitRepoName-pod-name -n namespace
+ `$ kubectl logs -f $gitRepoName-pod-name -n namespace`
 
 === Check the status of the `fleet-controller`?
 
@@ -175,6 +176,7 @@ endif::[]
 
 If your GitJob returns the error below, the problem may be that {product_name} cannot access the Helm repo you specified in your xref:reference/ref-fleet-yaml.adoc[`fleet.yaml`]:
 
+[source,text]
 ----
 time="2021-11-04T09:21:24Z" level=fatal msg="bad response code: 403"
 ----
@@ -190,6 +192,7 @@ If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex`
 
 When this happens, {product_name} logs a warning similar to:
 
+[source,text]
 ----
 helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
 ----
@@ -204,6 +207,7 @@ To fix this issue:
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:
 
+[source,text]
 ----
 time="2021-11-11T05:55:08Z" level=fatal msg="Get \"https://helm.intra/virtual-helm/index.yaml\": x509: certificate signed by unknown authority"
 ----

--- a/community-docs/v0.13/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/troubleshooting.adoc
@@ -184,6 +184,22 @@ Perform the following steps to assess:
 * Check that your repo is accessible from your dev machine, and that you can download the Helm chart successfully
 * Check that your credentials for the git repo are valid
 
+=== Helm credentials are not forwarded when `helmRepoURLRegex` is empty
+
+If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex` is empty, {product_name} does not forward those credentials to Helm repositories.
+
+When this happens, {product_name} logs a warning similar to:
+
+----
+helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
+----
+
+To fix this issue:
+
+* Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
+
 === Helm chart repo: certificate signed by unknown authority
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:

--- a/community-docs/v0.14/modules/ROOT/assets/attachments/crds/gitrepo_v1alpha1.json
+++ b/community-docs/v0.14/modules/ROOT/assets/attachments/crds/gitrepo_v1alpha1.json
@@ -80,7 +80,7 @@
           "type": "integer"
         },
         "helmRepoURLRegex": {
-          "description": "HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex\nCredentials will always be used if this is empty or not provided.",
+          "description": "HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex\nCredentials will not be used if this is empty or not provided.",
           "nullable": true,
           "type": "string"
         },

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -261,8 +261,8 @@ endif::[]
 
 [CAUTION]
 ====
-The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
-Make sure you don't leak credentials by mixing public and private repositories. Use <<Use different helm credentials for each path,different helm credentials for each path>>, or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
+Helm credentials are forwarded only when `helmRepoURLRegex` is set and matches the Helm repository URL.
+Use specific `helmRepoURLRegex` patterns so credentials are only forwarded to trusted Helm repository URLs. You can also use <<Use different helm credentials for each path,different helm credentials for each path>> or split charts into different gitrepos.
 ====
 
 

--- a/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
@@ -26,7 +26,7 @@ fleet apply [flags] BUNDLE_NAME PATH...
       --delete-namespace                       Delete GitRepo target namespace after the GitRepo or Bundle is deleted
   -f, --file string                            Location of the fleet.yaml
       --helm-credentials-by-path-file string   Path of file containing helm credentials for paths
-      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided
+      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will not be used if this is empty or not provided
   -h, --help                                   help for apply
       --keep-resources                         Keep resources created after the GitRepo or Bundle is deleted
   -k, --kubeconfig string                      kubeconfig for authentication

--- a/community-docs/v0.14/modules/ROOT/pages/reference/ref-crds.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/ref-crds.adoc
@@ -2312,7 +2312,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | false
 
 | helmRepoURLRegex
-| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will always be used if this is empty or not provided.
+| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will not be used if this is empty or not provided.
 | string
 | false
 

--- a/community-docs/v0.14/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -54,15 +54,15 @@ spec:
 
   # If fleet.yaml contains a private Helm repo that requires authentication,
   # provide the credentials in a K8s secret and specify them here.
-  # Danger: the credentials will be sent to all repositories referenced from
-  # this gitrepo. See section below for more information.
+  # Helm credentials are forwarded only when helmRepoURLRegex matches the
+  # Helm repository URL. See section below for more information.
   #
   # helmSecretName: my-helm-secret
 
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
-  # Credentials will always be used if it is empty or not provided
+  # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts\.rancher\.io/
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.14/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -62,7 +62,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts\.rancher\.io/
+  # helmRepoURLRegex: https://charts\.rancher\.io(/|$)
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.14/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/troubleshooting.adoc
@@ -199,7 +199,7 @@ helmRepoURLRegex is empty: Helm credentials will not be forwarded to any reposit
 To fix this issue:
 
 * Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
-* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com(/|$)`
 * If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
 
 === Helm chart repo: certificate signed by unknown authority

--- a/community-docs/v0.14/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/troubleshooting.adoc
@@ -29,12 +29,13 @@ Some of them can be automated through xref:reference/cli/fleet-cli/fleet_monitor
 
 In the local management cluster where the `fleet-controller` is deployed, run the following command with your specific `fleet-controller` pod name filled in:
 
- $ kubectl logs -l app=fleet-controller -n cattle-fleet-system
+ `$ kubectl logs -l app=fleet-controller -n cattle-fleet-system`
 
 === Fetch the log from the `fleet-agent`?
 
 Go to each downstream cluster and run the following command for the local cluster with your specific `fleet-agent` pod name filled in:
 
+[source,bash]
 ----
 # Downstream cluster
 $ kubectl logs -l app=fleet-agent -n cattle-fleet-system
@@ -79,13 +80,13 @@ Check the xref:troubleshooting.adoc#_fetch_the_log_from_fleet_controller[`fleet-
 
 Check the `gitjob-controller` logs using the following command with your specific `gitjob` pod name filled in:
 
- $ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system
+ `$ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system`
 
 Note that there are two containers inside the pod: the `step-git-source` container that clones the git repo, and the `fleet` container that applies bundles based on the git repo.
 
 The pods will usually have images named `rancher/tekton-utils` with the `gitRepo` name as a prefix. Check the logs for these Kubernetes job pods in the local management cluster as follows, filling in your specific `gitRepoName` pod name and namespace:
 
- $ kubectl logs -f $gitRepoName-pod-name -n namespace
+ `$ kubectl logs -f $gitRepoName-pod-name -n namespace`
 
 === Check the status of the `fleet-controller`?
 
@@ -177,6 +178,7 @@ endif::[]
 
 If your GitJob returns the error below, the problem may be that {product_name} cannot access the Helm repo you specified in your xref:reference/ref-fleet-yaml.adoc[`fleet.yaml`]:
 
+[source,text]
 ----
 time="2021-11-04T09:21:24Z" level=fatal msg="bad response code: 403"
 ----
@@ -192,6 +194,7 @@ If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex`
 
 When this happens, {product_name} logs a warning similar to:
 
+[source,text]
 ----
 helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
 ----
@@ -206,6 +209,7 @@ To fix this issue:
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:
 
+[source,text]
 ----
 time="2021-11-11T05:55:08Z" level=fatal msg="Get \"https://helm.intra/virtual-helm/index.yaml\": x509: certificate signed by unknown authority"
 ----

--- a/community-docs/v0.14/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/troubleshooting.adoc
@@ -186,6 +186,22 @@ Perform the following steps to assess:
 * Check that your repo is accessible from your dev machine, and that you can download the Helm chart successfully
 * Check that your credentials for the git repo are valid
 
+=== Helm credentials are not forwarded when `helmRepoURLRegex` is empty
+
+If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex` is empty, {product_name} does not forward those credentials to Helm repositories.
+
+When this happens, {product_name} logs a warning similar to:
+
+----
+helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
+----
+
+To fix this issue:
+
+* Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
+
 === Helm chart repo: certificate signed by unknown authority
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:

--- a/community-docs/v0.15/modules/ROOT/assets/attachments/crds/gitrepo_v1alpha1.json
+++ b/community-docs/v0.15/modules/ROOT/assets/attachments/crds/gitrepo_v1alpha1.json
@@ -80,7 +80,7 @@
           "type": "integer"
         },
         "helmRepoURLRegex": {
-          "description": "HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex\nCredentials will always be used if this is empty or not provided.",
+          "description": "HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex\nCredentials will not be used if this is empty or not provided.",
           "nullable": true,
           "type": "string"
         },

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/gitrepo-add.adoc
@@ -254,8 +254,8 @@ endif::[]
 
 [CAUTION]
 ====
-The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
-Make sure you don't leak credentials by mixing public and private repositories. Use <<Use different helm credentials for each path,different helm credentials for each path>>, or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
+Helm credentials are forwarded only when `helmRepoURLRegex` is set and matches the Helm repository URL.
+Use specific `helmRepoURLRegex` patterns so credentials are only forwarded to trusted Helm repository URLs. You can also use <<Use different helm credentials for each path,different helm credentials for each path>> or split charts into different gitrepos.
 ====
 
 

--- a/community-docs/v0.15/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/cli/fleet-cli/fleet_apply.adoc
@@ -27,7 +27,7 @@ fleet apply [flags] BUNDLE_NAME PATH...
       --delete-namespace                       Delete GitRepo target namespace after the GitRepo or Bundle is deleted
   -f, --file string                            Location of the fleet.yaml
       --helm-credentials-by-path-file string   Path of file containing helm credentials for paths
-      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will always be used if this is empty or not provided
+      --helm-repo-url-regex string             Helm credentials will be used if the helm repo matches this regex. Credentials will not be used if this is empty or not provided
   -h, --help                                   help for apply
       --keep-resources                         Keep resources created after the GitRepo or Bundle is deleted
   -k, --kubeconfig string                      kubeconfig for authentication

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-crds.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-crds.adoc
@@ -2312,7 +2312,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | false
 
 | helmRepoURLRegex
-| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will always be used if this is empty or not provided.
+| HelmRepoURLRegex Helm credentials will be used if the helm repo matches this regex Credentials will not be used if this is empty or not provided.
 | string
 | false
 

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -54,15 +54,15 @@ spec:
 
   # If fleet.yaml contains a private Helm repo that requires authentication,
   # provide the credentials in a K8s secret and specify them here.
-  # Danger: the credentials will be sent to all repositories referenced from
-  # this gitrepo. See section below for more information.
+  # Helm credentials are forwarded only when helmRepoURLRegex matches the
+  # Helm repository URL. See section below for more information.
   #
   # helmSecretName: my-helm-secret
 
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
-  # Credentials will always be used if it is empty or not provided
+  # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts\.rancher\.io/
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-gitrepo.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-gitrepo.adoc
@@ -62,7 +62,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will not be used if it is empty or not provided
   #
-  # helmRepoURLRegex: https://charts\.rancher\.io/
+  # helmRepoURLRegex: https://charts\.rancher\.io(/|$)
 
   # Contains the auth secret for private Helm repository for each path.
   

--- a/community-docs/v0.15/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/troubleshooting.adoc
@@ -199,7 +199,7 @@ helmRepoURLRegex is empty: Helm credentials will not be forwarded to any reposit
 To fix this issue:
 
 * Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
-* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com(/|$)`
 * If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
 
 === Helm chart repo: certificate signed by unknown authority

--- a/community-docs/v0.15/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/troubleshooting.adoc
@@ -29,12 +29,14 @@ Some of them can be automated through xref:reference/cli/fleet-cli/fleet_monitor
 
 In the local management cluster where the `fleet-controller` is deployed, run the following command with your specific `fleet-controller` pod name filled in:
 
- $ kubectl logs -l app=fleet-controller -n cattle-fleet-system
+ `$ kubectl logs -l app=fleet-controller -n cattle-fleet-system`
 
 === Fetch the log from the `fleet-agent`?
 
 Go to each downstream cluster and run the following command for the local cluster with your specific `fleet-agent` pod name filled in:
 
+
+[source,bash]
 ----
 # Downstream cluster
 $ kubectl logs -l app=fleet-agent -n cattle-fleet-system
@@ -79,13 +81,13 @@ Check the xref:troubleshooting.adoc#_fetch_the_log_from_fleet_controller[`fleet-
 
 Check the `gitjob-controller` logs using the following command with your specific `gitjob` pod name filled in:
 
- $ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system
+ `$ kubectl logs -f $gitjob-pod-name -n cattle-fleet-system`
 
 Note that there are two containers inside the pod: the `step-git-source` container that clones the git repo, and the `fleet` container that applies bundles based on the git repo.
 
 The pods will usually have images named `rancher/tekton-utils` with the `gitRepo` name as a prefix. Check the logs for these Kubernetes job pods in the local management cluster as follows, filling in your specific `gitRepoName` pod name and namespace:
 
- $ kubectl logs -f $gitRepoName-pod-name -n namespace
+ `$ kubectl logs -f $gitRepoName-pod-name -n namespace`
 
 === Check the status of the `fleet-controller`?
 
@@ -177,6 +179,7 @@ endif::[]
 
 If your GitJob returns the error below, the problem may be that {product_name} cannot access the Helm repo you specified in your xref:reference/ref-fleet-yaml.adoc[`fleet.yaml`]:
 
+[source,text]
 ----
 time="2021-11-04T09:21:24Z" level=fatal msg="bad response code: 403"
 ----
@@ -192,6 +195,7 @@ If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex`
 
 When this happens, {product_name} logs a warning similar to:
 
+[source,text]
 ----
 helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
 ----
@@ -206,6 +210,7 @@ To fix this issue:
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:
 
+[source,text]
 ----
 time="2021-11-11T05:55:08Z" level=fatal msg="Get \"https://helm.intra/virtual-helm/index.yaml\": x509: certificate signed by unknown authority"
 ----

--- a/community-docs/v0.15/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/troubleshooting.adoc
@@ -186,6 +186,22 @@ Perform the following steps to assess:
 * Check that your repo is accessible from your dev machine, and that you can download the Helm chart successfully
 * Check that your credentials for the git repo are valid
 
+=== Helm credentials are not forwarded when `helmRepoURLRegex` is empty
+
+If Helm credentials are configured in an auth secret but `spec.helmRepoURLRegex` is empty, {product_name} does not forward those credentials to Helm repositories.
+
+When this happens, {product_name} logs a warning similar to:
+
+----
+helmRepoURLRegex is empty: Helm credentials will not be forwarded to any repository; set spec.helmRepoURLRegex to enable credential forwarding
+----
+
+To fix this issue:
+
+* Set `spec.helmRepoURLRegex` on the `GitRepo` so it matches the Helm repository URL prefixes you trust.
+* Regex matching is automatically anchored at the start of the repository URL. Use patterns with a protocol prefix, for example: `https://charts\.example\.com/`
+* If you are upgrading from an older release, review auto-migrated `helmRepoURLRegex` values and tighten them if they are broader than necessary.
+
 === Helm chart repo: certificate signed by unknown authority
 
 If your GitJob returns the error below, you may have added the wrong certificate chain:


### PR DESCRIPTION
Align docs with v0.12+ behavior where Helm credentials are forwarded only when helmRepoURLRegex matches.

Update GitRepo and CLI references, CRD descriptions, and regex examples in v0.12, v0.13, v0.14, v0.15, and next.

Add troubleshooting guidance for empty helmRepoURLRegex and the related warning log message.

Document that regexes are auto-anchored and examples should start with a protocol-prefixed repository URL pattern.