### PR TITLE
Fix for PR 283

### DIFF
--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -66,6 +66,71 @@ in all namespaces that match `namespaceSelector`. One can specify labels for the
 created bundles from git by putting labels in the `fleet.yaml` file or on the
 `metadata.labels` field on the `GitRepo`.
 
+[#_restricting_gitrepos]
+=== Restricting GitRepos
+
+A namespace can contain multiple `GitRepoRestriction` resources. All `GitRepos`
+created in that namespace will be checked against the list of restrictions. If a
+`GitRepo` violates one of the constraints its `BundleDeployment` will be in an
+error state and won't be deployed.
+
+This can also be used to set the defaults for GitRepo's `serviceAccount` and
+`clientSecretName` fields.
+
+[,yaml]
+----
+kind: GitRepoRestriction
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: restriction
+  namespace: typically-unique
+allowedClientSecretNames: []
+allowedRepoPatterns: []
+allowedServiceAccounts: []
+allowedTargetNamespaces: []
+defaultClientSecretName: ""
+defaultServiceAccount: ""
+----
+
+==== Allowed Target Namespaces
+
+This can be used to limit a deployment to a set of namespaces on a downstream
+cluster. If an allowedTargetNamespaces restriction is present, all `GitRepos`
+must specify a `targetNamespace` and the specified namespace must be in the
+allow list. This also prevents the creation of cluster wide resources.
+
+==== Allowed target namespace selector
+
+`allowedTargetNamespaceSelector` restricts deployments to namespaces on
+downstream clusters whose labels match the given selector. When this field is
+set in a `GitRepoRestriction`, all `GitRepos` must specify a `targetNamespace`.
+The Fleet agent checks the labels of that namespace on the downstream cluster
+before deploying a bundle:
+
+* If the namespace exists and its labels match the selector, deployment proceeds.
+* If the namespace exists but its labels do not match, the `BundleDeployment` is
+* set to an error state and the bundle is not deployed.
+* If the namespace does not exist on the downstream cluster, the deployment fails
+  with an error. Pre-creating the namespace and labelling it correctly is
+  required; Helm's `createNamespace` option does not apply when this selector is
+  set.
+
+Multiple `GitRepoRestriction` resources in the same namespace each contribute
+their `allowedTargetNamespaceSelector`. The selectors are merged before being
+propagated to bundle deployments; a namespace must satisfy all of them.
+
+[source,yaml]
+----
+kind: GitRepoRestriction
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: restriction
+  namespace: workspace1
+allowedTargetNamespaceSelector:
+  matchLabels:
+    team: frontend
+----
+
 === Restricting What Tenants May Do in a Namespace
 
 A namespace can contain one or more `Policy` resources that restrict which service accounts, credential secrets, and source repositories the `GitRepo`, `HelmOp`, and `Bundle` resources in that namespace may use. Downstream namespace restrictions are not expressed at this layer — they are encoded as RBAC on the tenant's downstream `ServiceAccount`. See xref:explanations/multi-tenancy.adoc[Multi-Tenancy] for the trust model and xref:how-tos-for-operators/tenant-setup.adoc[Tenant Setup] for the operator recipe.

--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -101,8 +101,8 @@ allow list. This also prevents the creation of cluster-wide resources.
 
 ==== Allowed target namespace selector
 
-`allowedTargetNamespaceSelector` restricts deployments to namespaces on
-downstream clusters whose labels match the given selector. When this field is
+`allowedTargetNamespaceSelector` restricts deployments, on downstream clusters, to namespaces
+with labels matching the given selector. When this field is
 set in a `GitRepoRestriction`, all `GitRepos` must specify a `targetNamespace`.
 The Fleet agent checks the labels of that namespace on the downstream cluster
 before deploying a bundle:

--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -95,7 +95,7 @@ defaultServiceAccount: ""
 ==== Allowed Target Namespaces
 
 This can be used to limit a deployment to a set of namespaces on a downstream
-cluster. If an allowedTargetNamespaces restriction is present, all `GitRepos`
+cluster. If an `allowedTargetNamespaces` restriction is present, all `GitRepos`
 must specify a `targetNamespace` and the specified namespace must be in the
 allow list. This also prevents the creation of cluster wide resources.
 

--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -109,7 +109,7 @@ before deploying a bundle:
 
 * If the namespace exists and its labels match the selector, deployment proceeds.
 * If the namespace exists but its labels do not match, the `BundleDeployment` is
-* set to an error state and the bundle is not deployed.
+set to an error state and the bundle is not deployed.
 * If the namespace does not exist on the downstream cluster, the deployment fails
   with an error. Pre-creating the namespace and labelling it correctly is
   required; Helm's `createNamespace` option does not apply when this selector is

--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -97,7 +97,7 @@ defaultServiceAccount: ""
 This can be used to limit a deployment to a set of namespaces on a downstream
 cluster. If an `allowedTargetNamespaces` restriction is present, all `GitRepos`
 must specify a `targetNamespace` and the specified namespace must be in the
-allow list. This also prevents the creation of cluster wide resources.
+allow list. This also prevents the creation of cluster-wide resources.
 
 ==== Allowed target namespace selector
 

--- a/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/namespaces.adoc
@@ -69,6 +69,11 @@ created bundles from git by putting labels in the `fleet.yaml` file or on the
 [#_restricting_gitrepos]
 === Restricting GitRepos
 
+[IMPORTANT]
+====
+The `GitRepoRestriction` resource is deprecated and would be removed in a future release. For comprehensive multi-tenant environment governance, it is highly recommended to use the new `Policy` resource instead. For more information, refer to xref:_restricting_tenant_deployments_multi_tenancy[restricting tenant deployments for multi tenancy].
+====
+
 A namespace can contain multiple `GitRepoRestriction` resources. All `GitRepos`
 created in that namespace will be checked against the list of restrictions. If a
 `GitRepo` violates one of the constraints its `BundleDeployment` will be in an
@@ -131,6 +136,7 @@ allowedTargetNamespaceSelector:
     team: frontend
 ----
 
+[#_restricting_tenant_deployments_multi_tenancy]
 === Restricting What Tenants May Do in a Namespace
 
 A namespace can contain one or more `Policy` resources that restrict which service accounts, credential secrets, and source repositories the `GitRepo`, `HelmOp`, and `Bundle` resources in that namespace may use. Downstream namespace restrictions are not expressed at this layer — they are encoded as RBAC on the tenant's downstream `ServiceAccount`. See xref:explanations/multi-tenancy.adoc[Multi-Tenancy] for the trust model and xref:how-tos-for-operators/tenant-setup.adoc[Tenant Setup] for the operator recipe.

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
@@ -1,7 +1,7 @@
 = Tenant Setup
 :revdate: 2026-05-21
 :page-revdate: {revdate}
-:page-aliases: /how-tos-for-operators/multi-user, /multi-user, /tenant-setup
+:page-aliases: /tenant-setup
 
 This guide applies only to setups where multiple independent teams share a {product_name} manager. If all users are administrators with full trust, none of this is required.
 

--- a/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-operators/tenant-setup.adoc
@@ -1,7 +1,7 @@
 = Tenant Setup
 :revdate: 2026-05-21
 :page-revdate: {revdate}
-:page-aliases: /tenant-setup
+:page-aliases: /how-tos-for-operators/multi-user, /multi-user, /tenant-setup
 
 This guide applies only to setups where multiple independent teams share a {product_name} manager. If all users are administrators with full trust, none of this is required.
 

--- a/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
+++ b/community-docs/next/modules/ROOT/pages/tutorials/best-practices.adoc
@@ -358,10 +358,22 @@ By default, {product_name} stores Kubernetes bundle resources directly in the et
 
 * Reference: xref:reference/ref-crds.adoc[{product_name} CRD Reference].
 
+[#_restricting_tenant_deployments_multi_tenancy]
 === Restricting Tenant Deployments (Multi-Tenancy)
 
 *The Best Practice:* In multi-tenant environments, prevent tenants from running deployments with privileged service accounts or pulling from unauthorized repositories.
 
 *The Implementation:* Create a ++Policy++ resource in each tenant's namespace, declaring ++requireServiceAccount: true++, the allowed ++ServiceAccount++ list, and source/credential allow-lists for ++GitRepo++ and ++HelmOp++ resources. Restrict tenants to read-only RBAC on ++Policy++ objects. Express which downstream namespaces a tenant may deploy to as RBAC on the tenant's downstream ++ServiceAccount++, not at the {product_name} layer.
 
+[NOTE]
+====
+`allowedRepoPatterns` supports regular expressions which will be matched on a _substring_ basis. This means that an
+expression such as `\https://example.site/org` may have more matches than intended, not limited to `example.site` hosts.
+
+To mitigate that, you should anchor regular expressions used in `allowedRepoPatterns`. The above example could become
+`^https://example.site/org`.
+====
+
 * Reference: xref:explanations/multi-tenancy.adoc[Multi-Tenancy] and xref:how-tos-for-operators/tenant-setup.adoc[Tenant Setup].
+
+

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -204,6 +204,8 @@ allowedTargetNamespaces:
 
 This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
+Check out xref:tutorials/best-practices.adoc#_restricting_tenant_deployments_multi_tenancy[best practices] for `GitRepoRestrictions`.
+
 == An Example GitRepo Resource
 
 A GitRepo resource created by a tenant, without admin access could look like this:

--- a/community-docs/v0.14/modules/ROOT/pages/tutorials/best-practices.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/tutorials/best-practices.adoc
@@ -358,10 +358,21 @@ By default, {product_name} stores Kubernetes bundle resources directly in the et
 
 * Reference: xref:reference/ref-crds.adoc[{product_name} CRD Reference].
 
-=== Restricting GitRepo Deployments (Multi-Tenancy)
+[#_restricting_tenant_deployments_multi_tenancy]
+=== Restricting Tenant Deployments (Multi-Tenancy)
 
 *The Best Practice:* In multi-tenant environments, prevent users from deploying bundles into unauthorized namespaces or using restricted service accounts.
 
-*The Implementation:* Deploy a ++GitRepoRestriction++ CRD. This allows administrators to define whitelists for ++allowedTargetNamespaces++, ++allowedServiceAccounts++, and ++allowedRepoPatterns++.
+*The Implementation:* Create a ++Policy++ resource in each tenant's namespace, declaring ++requireServiceAccount: true++, the allowed ++ServiceAccount++ list, and source/credential allow-lists for ++GitRepo++ and ++HelmOp++ resources. Restrict tenants to read-only RBAC on ++Policy++ objects. Express which downstream namespaces a tenant may deploy to as RBAC on the tenant's downstream ++ServiceAccount++, not at the {product_name} layer.
+
+[NOTE]
+====
+`allowedRepoPatterns` supports regular expressions which will be matched on a _substring_ basis. This means that an
+expression such as `\https://example.site/org` may have more matches than intended, not limited to `example.site` hosts.
+
+To mitigate that, you should anchor regular expressions used in `allowedRepoPatterns`. The above example could become
+`^https://example.site/org`.
+====
+
 
 * Reference: xref:reference/ref-crd-schema.adoc[{product_name} CRD Schema].

--- a/community-docs/v0.15/modules/ROOT/pages/explanations/namespaces.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/explanations/namespaces.adoc
@@ -162,6 +162,11 @@ registered through Rancher.
 * `fleet-local` will contain the local cluster by default. Access to
 `fleet-local` is limited.
 
+When Rancher creates a workspace:
+
+* Rancher creates a role binding that grants the workspace creator cluster-wide read and write permissions on all {product_name} resources. (The `FleetWorkspace` is a cluster-scoped resource.)
+* Regular users have read and write permissions only on GitRepos and bundles. They have read permissions (get, list, and watch) on the remaining {product_name} resources.
+
 [WARNING] 
 .Important Information
 ====

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-operators/multi-user.adoc
@@ -204,6 +204,8 @@ allowedTargetNamespaces:
 
 This will deny the creation of cluster wide resources, which may interfere with other tenants and limit the deployment to the 'workspace1simpleapp' namespace.
 
+Check out xref:tutorials/best-practices.adoc#_restricting_tenant_deployments_multi_tenancy[best practices] for `GitRepoRestrictions`.
+
 == An Example GitRepo Resource
 
 A GitRepo resource created by a tenant, without admin access could look like this:

--- a/community-docs/v0.15/modules/ROOT/pages/tutorials/best-practices.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/tutorials/best-practices.adoc
@@ -358,10 +358,20 @@ By default, {product_name} stores Kubernetes bundle resources directly in the et
 
 * Reference: xref:reference/ref-crds.adoc[{product_name} CRD Reference].
 
-=== Restricting GitRepo Deployments (Multi-Tenancy)
+[#_restricting_tenant_deployments_multi_tenancy]
+=== Restricting Tenant Deployments (Multi-Tenancy)
 
 *The Best Practice:* In multi-tenant environments, prevent users from deploying bundles into unauthorized namespaces or using restricted service accounts.
 
-*The Implementation:* Deploy a ++GitRepoRestriction++ CRD. This allows administrators to define whitelists for ++allowedTargetNamespaces++, ++allowedServiceAccounts++, and ++allowedRepoPatterns++.
+*The Implementation:* Create a ++Policy++ resource in each tenant's namespace, declaring ++requireServiceAccount: true++, the allowed ++ServiceAccount++ list, and source/credential allow-lists for ++GitRepo++ and ++HelmOp++ resources. Restrict tenants to read-only RBAC on ++Policy++ objects. Express which downstream namespaces a tenant may deploy to as RBAC on the tenant's downstream ++ServiceAccount++, not at the {product_name} layer.
+
+[NOTE]
+====
+`allowedRepoPatterns` supports regular expressions which will be matched on a _substring_ basis. This means that an
+expression such as `\https://example.site/org` may have more matches than intended, not limited to `example.site` hosts.
+
+To mitigate that, you should anchor regular expressions used in `allowedRepoPatterns`. The above example could become
+`^https://example.site/org`.
+====
 
 * Reference: xref:reference/ref-crd-schema.adoc[{product_name} CRD Schema].


### PR DESCRIPTION
This clarifies that, in GitRepoRestrictions, allowedRepoPatterns are matched as substrings, and should be anchored for restricting matches.

Refers to https://github.com/rancher/fleet-product-docs/issues/270.
This is a copy of https://github.com/rancher/fleet-product-docs/pull/283