### PR TITLE
Document v0.16 debug troubleshooting

### DIFF
--- a/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
@@ -116,6 +116,15 @@ CTRL_POD=$(kubectl get pod -n $FLEET_NS -l app=fleet-controller -o jsonpath='{.i
 kubectl debug $CTRL_POD -n $FLEET_NS -it --image=busybox --target=fleet-controller -- sh
 ----
 
+Example: open a shell with a debug container targeting `fleet-agent`:
+
+[,shell]
+----
+AGENT_NS=cattle-fleet-local-system
+AGENT_POD=$(kubectl get pod -n $AGENT_NS -l app=fleet-agent -o jsonpath='{.items[0].metadata.name}')
+kubectl debug $AGENT_POD -n $AGENT_NS -it --image=busybox --target=fleet-agent -- sh
+----
+
 Trying to run `kubectl exec <pod> -- sh` is expected to fail in v0.16 with an error like `executable file not found in $PATH`.
 
 === Enable debug logging for `fleet-controller` and `fleet-agent`?

--- a/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
@@ -104,9 +104,9 @@ NAME                                READY   STATUS    RESTARTS   AGE
 fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 
-=== Debug `fleet-controller` and `fleet-agent` containers in v0.16
+=== Debug fleet-controller and fleet-agent containers 
 
-For Fleet v0.16, runtime images use `bci-nano` and do not include a shell.
+For {product_name} v0.16, runtime images use `bci-nano` and do not include a shell.
 Use `kubectl debug` with `--target` to inspect a running Fleet container.
 
 [,shell]
@@ -116,7 +116,7 @@ CTRL_POD=$(kubectl get pod -n $FLEET_NS -l app=fleet-controller -o jsonpath='{.i
 kubectl debug $CTRL_POD -n $FLEET_NS -it --image=busybox --target=fleet-controller -- sh
 ----
 
-Example: open a shell with a debug container targeting `fleet-agent`:
+For example, open a shell with a debug container targeting `fleet-agent`:
 
 [,shell]
 ----

--- a/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
+++ b/community-docs/next/modules/ROOT/pages/troubleshooting.adoc
@@ -104,6 +104,20 @@ NAME                                READY   STATUS    RESTARTS   AGE
 fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ----
 
+=== Debug `fleet-controller` and `fleet-agent` containers in v0.16
+
+For Fleet v0.16, runtime images use `bci-nano` and do not include a shell.
+Use `kubectl debug` with `--target` to inspect a running Fleet container.
+
+[,shell]
+----
+FLEET_NS=cattle-fleet-system
+CTRL_POD=$(kubectl get pod -n $FLEET_NS -l app=fleet-controller -o jsonpath='{.items[0].metadata.name}')
+kubectl debug $CTRL_POD -n $FLEET_NS -it --image=busybox --target=fleet-controller -- sh
+----
+
+Trying to run `kubectl exec <pod> -- sh` is expected to fail in v0.16 with an error like `executable file not found in $PATH`.
+
 === Enable debug logging for `fleet-controller` and `fleet-agent`?
 
 Available in Rancher v2.6.3 ({product_name} v0.3.8), the ability to enable debug logging has been added.
@@ -275,7 +289,7 @@ A `GitRepo` may stop syncing and remain in a **Failed** state. In this case, the
 
 {product_name} retries apply operations when it detects a resource version conflict. The number of retry attempts is controlled by the `FLEET_APPLY_CONFLICT_RETRIES` environment variable.
 
-The default value is `1`. This means {product_name} only tries the bundle creation or update once, not retrying if a conflict occurs. If conflicts occur frequently under heavy load, increase this value to allow additional retry attempts. Configure this variable as an environment variable on the GitJob deployment. 
+The default value is `1`. This means {product_name} only tries the bundle creation or update once, not retrying if a conflict occurs. If conflicts occur frequently under heavy load, increase this value to allow additional retry attempts. Configure this variable as an environment variable on the GitJob deployment.
 
 For example, when installing with Helm:
 


### PR DESCRIPTION
Add a troubleshooting section for Fleet `v0.16` that explains using `kubectl debug` for container inspection and clarifies that `kubectl exec ... -- sh` is expected to fail on `bci-nano` images.

The Rancher documentation also needs to be updated in a similar way.

Followup to https://github.com/rancher/fleet/issues/5407