### PR TITLE
Remove optional marker on OCI artifact version

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -105,11 +105,10 @@ In this case, Helm options would be similar to this:
 ----
   helm:
     repo: oci://foo.bar/baz
-    version: '1.2.3' # optional
+    version: '1.2.3'
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.
-
 
 [NOTE]
 ====

--- a/community-docs/next/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -408,7 +408,7 @@ The chart reference can be one of the following:
 * https://github.com/hashicorp/go-getter?tab=readme-ov-file#url-format[go-getter URL] (`chart`)
 * OCI chart URL (`repo: oci://...`)
 * Helm repository (`repo` + `chart` + optional `version`)
-* OCI Helm repository (`repo: oci://...` + optional `version`)
+* OCI Helm repository (`repo: oci://...` + `version`)
 
 ==== `helm.repo`
 
@@ -418,7 +418,7 @@ For OCI registries, `helm.repo` is the canonical field for the OCI URL. Use it l
 ----
 helm:
   repo: "oci://ghcr.io/fleetrepoci/guestbook"
-  version: "0.1.0"  # optional
+  version: "0.1.0"
 ----
 
 This is consistent with how OCI registries are referenced in xref:how-tos-for-users/helm-ops.adoc#oci-registry[HelmOp resources].

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -100,11 +100,10 @@ In this case, Helm options would be similar to this:
 ----
   helm:
     repo: oci://foo.bar/baz
-    version: '1.2.3' # optional
+    version: '1.2.3'
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.
-
 
 [NOTE]
 ====

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -100,11 +100,10 @@ In this case, Helm options would be similar to this:
 ----
   helm:
     repo: oci://foo.bar/baz
-    version: '1.2.3' # optional
+    version: '1.2.3'
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.
-
 
 [NOTE]
 ====

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -101,11 +101,10 @@ In this case, Helm options would be similar to this:
 ----
   helm:
     repo: oci://foo.bar/baz
-    version: '1.2.3' # optional
+    version: '1.2.3'
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.
-
 
 [NOTE]
 ====

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/helm-ops.adoc
@@ -101,11 +101,10 @@ In this case, Helm options would be similar to this:
 ----
   helm:
     repo: oci://foo.bar/baz
-    version: '1.2.3' # optional
+    version: '1.2.3'
 ----
 
 When an OCI URL is provided in the ++repo++ field, a non-empty ++chart++ field will lead to an error in the HelmOps status, and no bundle being created.
-
 
 [NOTE]
 ====

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -408,7 +408,7 @@ The chart reference can be one of the following:
 * https://github.com/hashicorp/go-getter?tab=readme-ov-file#url-format[go-getter URL] (`chart`)
 * OCI chart URL (`repo: oci://...`)
 * Helm repository (`repo` + `chart` + optional `version`)
-* OCI Helm repository (`repo: oci://...` + optional `version`)
+* OCI Helm repository (`repo: oci://...` + `version`)
 
 ==== `helm.repo`
 
@@ -418,7 +418,7 @@ For OCI registries, `helm.repo` is the canonical field for the OCI URL. Use it l
 ----
 helm:
   repo: "oci://ghcr.io/fleetrepoci/guestbook"
-  version: "0.1.0"  # optional
+  version: "0.1.0"
 ----
 
 This is consistent with how OCI registries are referenced in xref:how-tos-for-users/helm-ops.adoc#oci-registry[HelmOp resources].


### PR DESCRIPTION
When fetching Helm charts as OCI artifacts, the `version` field cannot be optional, as it represents an OCI tag.

Chart versions stored in an `index.yaml`, which can be ordered as semantic versions, enable Fleet to fetch the latest version if none is provided by the user.

But OCI registries do not work that way: an OCI tag can bear a value which does not comply with semantic versioning.