### PR TITLE
Fix rendering of `+` character

### DIFF
--- a/community-docs/next/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -465,8 +465,8 @@ Determines which chart to download from OCI registries.
 
 [NOTE]
 ====
-OCI registries do not support the `+` character in semver tags. Helm replaces `+` with `_` automatically when pushing charts.  
-Use the `+` version in `fleet.yaml`; {product_name} performs the same replacement internally.
+OCI registries do not support the `{plus}` character in semver tags. Helm replaces `{plus}` with `_` automatically when pushing charts.
+Use the `{plus}` version in `fleet.yaml`; {product_name} performs the same replacement internally.
 ====
 
 === Values

--- a/community-docs/v0.10/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.10/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -162,9 +162,9 @@ See link:https://github.com/rancher/fleet/issues/3646[fleet#3646].
 
 [NOTE]
 ====
-`+` character support
+`{plus}` character support
 
-OCI registries don't support the `+` character.
+OCI registries don't support the `{plus}` character.
 ====
 
 === How fleet-agent deploys the bundle

--- a/community-docs/v0.11/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.11/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -165,9 +165,9 @@ The version also determines which chart to download from OCI registries.
 
 [NOTE]
 ====
-`+` character support
+`{plus}` character support
 
-OCI registries don't support the `+` character.
+OCI registries don't support the `{plus}` character.
 ====
 
 ==== How fleet-agent deploys the bundle

--- a/community-docs/v0.12/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -161,9 +161,9 @@ See link:https://github.com/rancher/fleet/issues/3646[fleet#3646].
 
 [NOTE]
 ====
-`+` character support
+`{plus}` character support
 
-OCI registries don't support the `+` character.
+OCI registries don't support the `{plus}` character.
 ====
 
 === How fleet-agent deploys the bundle

--- a/community-docs/v0.13/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -401,8 +401,8 @@ Determines which chart to download from OCI registries.
 
 [NOTE]
 ====
-OCI registries do not support the `+` character in semver tags. Helm replaces `+` with `_` automatically when pushing charts.  
-Use the `+` version in `fleet.yaml`; {product_name} performs the same replacement internally.
+OCI registries do not support the `{plus}` character in semver tags. Helm replaces `{plus}` with `_` automatically when pushing charts.
+Use the `{plus}` version in `fleet.yaml`; {product_name} performs the same replacement internally.
 ====
 
 === Values

--- a/community-docs/v0.14/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -422,8 +422,8 @@ Determines which chart to download from OCI registries.
 
 [NOTE]
 ====
-OCI registries do not support the `+` character in semver tags. Helm replaces `+` with `_` automatically when pushing charts.  
-Use the `+` version in `fleet.yaml`; {product_name} performs the same replacement internally.
+OCI registries do not support the `{plus}` character in semver tags. Helm replaces `{plus}` with `_` automatically when pushing charts.
+Use the `{plus}` version in `fleet.yaml`; {product_name} performs the same replacement internally.
 ====
 
 === Values

--- a/community-docs/v0.15/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -465,8 +465,8 @@ Determines which chart to download from OCI registries.
 
 [NOTE]
 ====
-OCI registries do not support the `+` character in semver tags. Helm replaces `+` with `_` automatically when pushing charts.  
-Use the `+` version in `fleet.yaml`; {product_name} performs the same replacement internally.
+OCI registries do not support the `{plus}` character in semver tags. Helm replaces `{plus}` with `_` automatically when pushing charts.
+Use the `{plus}` version in `fleet.yaml`; {product_name} performs the same replacement internally.
 ====
 
 === Values


### PR DESCRIPTION
In AsciiDoc, the plus sign is used as a continuation marker for lists. To be rendered unaltered, it must be written as `{plus}` [1].

[1]: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#lists