### PR TITLE
Add HelmOp to Core Concepts

### DIFF
--- a/community-docs/next/modules/ROOT/pages/explanations/concepts.adoc
+++ b/community-docs/next/modules/ROOT/pages/explanations/concepts.adoc
@@ -36,6 +36,9 @@ ____
 . Set up and configure ingress and system daemons.
 ____
 
+* *HelmOp*: Helm charts deployed directly from a Helm repository or OCI registry, without a git
+  repository, are represented by the type `HelmOp`.
+ ** For more details, click xref:how-tos-for-users/helm-ops.adoc[HelmOps].
 * *Bundle*: An internal unit used for the orchestration of resources from git.
   When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of
   resources that get deployed to a cluster. `Bundle` is the fundamental deployment unit used in{product_name}. The

--- a/community-docs/v0.12/modules/ROOT/pages/explanations/concepts.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/explanations/concepts.adoc
@@ -35,6 +35,9 @@ ____
 . Set up and configure ingress and system daemons.
 ____
 
+* *HelmOp*: Helm charts deployed directly from a Helm repository or OCI registry, without a git
+  repository, are represented by the type `HelmOp`.
+ ** For more details, click xref:how-tos-for-users/helm-ops.adoc[HelmOps].
 * *Bundle*: An internal unit used for the orchestration of resources from git.
   When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of
   resources that get deployed to a cluster. `Bundle` is the fundamental deployment unit used in{product_name}. The

--- a/community-docs/v0.13/modules/ROOT/pages/explanations/concepts.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/explanations/concepts.adoc
@@ -35,6 +35,9 @@ ____
 . Set up and configure ingress and system daemons.
 ____
 
+* *HelmOp*: Helm charts deployed directly from a Helm repository or OCI registry, without a git
+  repository, are represented by the type `HelmOp`.
+ ** For more details, click xref:how-tos-for-users/helm-ops.adoc[HelmOps].
 * *Bundle*: An internal unit used for the orchestration of resources from git.
   When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of
   resources that get deployed to a cluster. `Bundle` is the fundamental deployment unit used in{product_name}. The

--- a/community-docs/v0.14/modules/ROOT/pages/explanations/concepts.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/explanations/concepts.adoc
@@ -36,6 +36,9 @@ ____
 . Set up and configure ingress and system daemons.
 ____
 
+* *HelmOp*: Helm charts deployed directly from a Helm repository or OCI registry, without a git
+  repository, are represented by the type `HelmOp`.
+ ** For more details, click xref:how-tos-for-users/helm-ops.adoc[HelmOps].
 * *Bundle*: An internal unit used for the orchestration of resources from git.
   When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of
   resources that get deployed to a cluster. `Bundle` is the fundamental deployment unit used in{product_name}. The

--- a/community-docs/v0.15/modules/ROOT/pages/explanations/concepts.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/explanations/concepts.adoc
@@ -36,6 +36,9 @@ ____
 . Set up and configure ingress and system daemons.
 ____
 
+* *HelmOp*: Helm charts deployed directly from a Helm repository or OCI registry, without a git
+  repository, are represented by the type `HelmOp`.
+ ** For more details, click xref:how-tos-for-users/helm-ops.adoc[HelmOps].
 * *Bundle*: An internal unit used for the orchestration of resources from git.
   When a `GitRepo` is scanned it will produce one or more bundles. Bundles are a collection of
   resources that get deployed to a cluster. `Bundle` is the fundamental deployment unit used in{product_name}. The


### PR DESCRIPTION
Document the HelmOp resource type in the Core Concepts glossary, alongside GitRepo and Bundle, with a link to the HelmOps how-to.

