### PR TITLE
Update Ingress Nginx retirement statement

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -74,7 +74,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.10/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.10/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -57,7 +57,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.11/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.11/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -57,7 +57,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -69,7 +69,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -69,7 +69,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -70,7 +70,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -74,7 +74,7 @@ spec:
                 number: 80
 ----
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----

--- a/community-docs/v0.9/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.9/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -32,7 +32,7 @@ spec:
 ----
 
 
-Ingress Nginx will be https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
+Ingress Nginx has been https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/[retired], here is an example using Traefik:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Nginx was retired in March of this year.