### PR TITLE
Fix link to webhook example screenshot

### DIFF
--- a/community-docs/next/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/next/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -132,7 +132,7 @@ You can configure https://kubernetes.io/docs/concepts/services-networking/ingres
 Go to your Git provider and configure the webhook callback URL.  
 The following image shows an example from GitHub.
 
-image:: ../../images/webhook.png[]
+image::webhook.png[webhook example on Github]
 
 Configuring a secret is optional.  
 The secret is used to validate the webhook payload since the payload shouldn’t be trusted by default.

--- a/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.12/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -127,7 +127,7 @@ You can configure https://kubernetes.io/docs/concepts/services-networking/ingres
 Go to your Git provider and configure the webhook callback URL.  
 The following image shows an example from GitHub.
 
-image:: ../../images/webhook.png[]
+image::webhook.png[webhook example on Github]
 
 Configuring a secret is optional.  
 The secret is used to validate the webhook payload since the payload shouldn’t be trusted by default.

--- a/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.13/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -127,7 +127,7 @@ You can configure https://kubernetes.io/docs/concepts/services-networking/ingres
 Go to your Git provider and configure the webhook callback URL.  
 The following image shows an example from GitHub.
 
-image:: ../../images/webhook.png[]
+image::webhook.png[webhook example on Github]
 
 Configuring a secret is optional.  
 The secret is used to validate the webhook payload since the payload shouldn’t be trusted by default.

--- a/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.14/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -128,7 +128,7 @@ You can configure https://kubernetes.io/docs/concepts/services-networking/ingres
 Go to your Git provider and configure the webhook callback URL.  
 The following image shows an example from GitHub.
 
-image:: ../../images/webhook.png[]
+image::webhook.png[webhook example on Github]
 
 Configuring a secret is optional.  
 The secret is used to validate the webhook payload since the payload shouldn’t be trusted by default.

--- a/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.15/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -132,7 +132,7 @@ You can configure https://kubernetes.io/docs/concepts/services-networking/ingres
 Go to your Git provider and configure the webhook callback URL.  
 The following image shows an example from GitHub.
 
-image:: ../../images/webhook.png[]
+image::webhook.png[webhook example on Github]
 
 Configuring a secret is optional.  
 The secret is used to validate the webhook payload since the payload shouldn’t be trusted by default.

--- a/community-docs/v0.9/modules/ROOT/pages/how-tos-for-users/webhook.adoc
+++ b/community-docs/v0.9/modules/ROOT/pages/how-tos-for-users/webhook.adoc
@@ -89,7 +89,7 @@ You can configure https://kubernetes.io/docs/concepts/services-networking/ingres
 
 == 2. Go to your webhook provider and configure the webhook callback url. Here is a Github example.
 
-image::webhook.png[]
+image::webhook.png[webhook example on Github]
 
 Configuring a secret is optional. This is used to validate the webhook payload as the payload should not be trusted by default.
 If your webhook server is publicly accessible to the Internet, then it is recommended to configure the secret. If you do configure the


### PR DESCRIPTION
The screenshot can now be properly rendered on the webhook how-to page, and alternative text is available in case rendering fails.