### PR TITLE
docs(fleet.yaml): link to the full fleet.yaml JSON schema

### DIFF
--- a/community-docs/next/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
+++ b/community-docs/next/modules/ROOT/pages/reference/ref-fleet-yaml.adoc
@@ -349,6 +349,11 @@ overrideTargets:
 ----
 ====
 
+[NOTE]
+====
+For the complete `fleet.yaml` schema see https://github.com/rancher/fleet/issues/3646[latest fleet.yaml.json], or visit https://www.schemastore.org/[schemastore].
+====
+
 == General Bundle Configuration
 
 These options define the fundamental properties and behavior of the bundle itself and apply to all bundle types.


### PR DESCRIPTION
Point readers from the reference page to the canonical fleet.yaml.json schema and to schemastore, so the hand-maintained example on this page is not the only source for the full set of fields.

The approach avoids the need for any more complicated solution which would require either a CI job to update the context or a sync script. The reference is on he main currently, but it would be easy to point the readers to other releases if it is decided to generate a schema per release.

related issue: https://github.com/rancher/fleet/issues/1962
depends-on: https://github.com/rancher/fleet/pull/5507